### PR TITLE
Add HTML options (escape HTML input & replace image w/ text link) 

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -29,7 +29,7 @@ const DEFAULT_TITLE = ""
 
 func main() {
 	// parse command-line options
-	var page, toc, toconly, xhtml, latex, smartypants, latexdashes, fractions, htmlesc, imglink bool
+	var page, toc, toconly, xhtml, latex, smartypants, latexdashes, fractions, htmlesc, img2link bool
 	var css, cpuprofile string
 	var repeat int
 	flag.BoolVar(&page, "page", false,
@@ -42,7 +42,7 @@ func main() {
 		"Use XHTML-style tags in HTML output")
 	flag.BoolVar(&htmlesc, "htmlesc", false,
 		"Escape html tags within source text.")
-	flag.BoolVar(&imglink, "imglink", false,
+	flag.BoolVar(&img2link, "img2link", false,
 		"Replace embedded images with links to the images.")
 	flag.BoolVar(&latex, "latex", false,
 		"Generate LaTeX output instead of HTML")
@@ -147,8 +147,8 @@ func main() {
 		if htmlesc {
 			htmlFlags |= blackfriday.HTML_ESCAPE_HTML
 		}
-		if imglink {
-			htmlFlags |= blackfriday.HTML_LINK_IMAGES
+		if img2link {
+			htmlFlags |= blackfriday.HTML_REPLACE_IMAGES
 		}
 		title := ""
 		if page {

--- a/example/main.go
+++ b/example/main.go
@@ -42,7 +42,7 @@ func main() {
 		"Use XHTML-style tags in HTML output")
 	flag.BoolVar(&htmlesc, "htmlesc", false,
 		"Escape html tags within source text.")
-	flag.BoolVar(&imglink, "imglink", true,
+	flag.BoolVar(&imglink, "imglink", false,
 		"Replace embedded images with links to the images.")
 	flag.BoolVar(&latex, "latex", false,
 		"Generate LaTeX output instead of HTML")

--- a/example/main.go
+++ b/example/main.go
@@ -29,7 +29,7 @@ const DEFAULT_TITLE = ""
 
 func main() {
 	// parse command-line options
-	var page, toc, toconly, xhtml, latex, smartypants, latexdashes, fractions bool
+	var page, toc, toconly, xhtml, latex, smartypants, latexdashes, fractions, htmlesc, imglink bool
 	var css, cpuprofile string
 	var repeat int
 	flag.BoolVar(&page, "page", false,
@@ -40,6 +40,10 @@ func main() {
 		"Generate a table of contents only (implies -toc)")
 	flag.BoolVar(&xhtml, "xhtml", true,
 		"Use XHTML-style tags in HTML output")
+	flag.BoolVar(&htmlesc, "htmlesc", false,
+		"Escape html tags within source text.")
+	flag.BoolVar(&imglink, "imglink", true,
+		"Replace embedded images with links to the images.")
 	flag.BoolVar(&latex, "latex", false,
 		"Generate LaTeX output instead of HTML")
 	flag.BoolVar(&smartypants, "smartypants", true,
@@ -139,6 +143,12 @@ func main() {
 		}
 		if latexdashes {
 			htmlFlags |= blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
+		}
+		if htmlesc {
+			htmlFlags |= blackfriday.HTML_ESCAPE_HTML
+		}
+		if imglink {
+			htmlFlags |= blackfriday.HTML_LINK_IMAGES
 		}
 		title := ""
 		if page {

--- a/html.go
+++ b/html.go
@@ -28,7 +28,7 @@ const (
 	HTML_ESCAPE_HTML                          // escape embedded HTML
 	HTML_SKIP_STYLE                           // skip embedded <style> elements
 	HTML_SKIP_IMAGES                          // skip embedded images
-	HTML_LINK_IMAGES                          // replace embedded images with links
+	HTML_REPLACE_IMAGES                       // replace embedded images with links
 	HTML_SKIP_LINKS                           // skip all links
 	HTML_SAFELINK                             // only link to trusted protocols
 	HTML_TOC                                  // generate a table of contents
@@ -405,7 +405,7 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 		return
 	}
 
-	if options.flags&HTML_LINK_IMAGES != 0 {
+	if options.flags&HTML_REPLACE_IMAGES != 0 {
 		title := title
 		switch {
 		case len(title) > 0:

--- a/html.go
+++ b/html.go
@@ -406,17 +406,20 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 	}
 
 	if options.flags&HTML_LINK_IMAGES != 0 {
-		out.WriteString(`<a href="`)
-		attrEscape(out, link)
-		out.WriteString(`">`)
+		title := title
 		switch {
 		case len(title) > 0:
-			attrEscape(out, title)
 		case len(alt) > 0:
-			attrEscape(out, alt)
+			title = alt
 		default:
-			attrEscape(out, link)
+			title = link
 		}
+		out.WriteString(`<a href="`)
+		attrEscape(out, link)
+		out.WriteString(`" title="`)
+		attrEscape(out, title)
+		out.WriteString(`">`)
+		attrEscape(out, title)
 		out.WriteString("</a>")
 		return
 	}

--- a/html.go
+++ b/html.go
@@ -25,10 +25,10 @@ import (
 // Html renderer configuration options.
 const (
 	HTML_SKIP_HTML                = 1 << iota // skip preformatted HTML blocks
-    HTML_ESCAPE_HTML                          // escape embedded HTML               -bmatsuo
+    HTML_ESCAPE_HTML                          // escape embedded HTML
 	HTML_SKIP_STYLE                           // skip embedded <style> elements
 	HTML_SKIP_IMAGES                          // skip embedded images
-    HTML_LINK_IMAGES                          // replace embedded images with links -bmatsuo
+    HTML_LINK_IMAGES                          // replace embedded images with links
 	HTML_SKIP_LINKS                           // skip all links
 	HTML_SAFELINK                             // only link to trusted protocols
 	HTML_TOC                                  // generate a table of contents
@@ -412,7 +412,8 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
         out.WriteString(`">`)
         if len(title) > 0 {
             attrEscape(out, title)
-        }
+		}
+        out.WriteString("</a>")
         return
     }
 

--- a/html.go
+++ b/html.go
@@ -25,10 +25,10 @@ import (
 // Html renderer configuration options.
 const (
 	HTML_SKIP_HTML                = 1 << iota // skip preformatted HTML blocks
-    HTML_ESCAPE_HTML                          // escape embedded HTML
+	HTML_ESCAPE_HTML                          // escape embedded HTML
 	HTML_SKIP_STYLE                           // skip embedded <style> elements
 	HTML_SKIP_IMAGES                          // skip embedded images
-    HTML_LINK_IMAGES                          // replace embedded images with links
+	HTML_LINK_IMAGES                          // replace embedded images with links
 	HTML_SKIP_LINKS                           // skip all links
 	HTML_SAFELINK                             // only link to trusted protocols
 	HTML_TOC                                  // generate a table of contents
@@ -169,11 +169,11 @@ func (options *Html) BlockHtml(out *bytes.Buffer, text []byte) {
 	}
 
 	doubleSpace(out)
-    if options.flags&HTML_ESCAPE_HTML != 0 {
-        attrEscape(out, text)
-    } else {
-	    out.Write(text)
-    }
+	if options.flags&HTML_ESCAPE_HTML != 0 {
+		attrEscape(out, text)
+	} else {
+		out.Write(text)
+	}
 	out.WriteByte('\n')
 }
 
@@ -266,7 +266,6 @@ func (options *Html) BlockCodeGithub(out *bytes.Buffer, text []byte, lang string
 	attrEscape(out, text)
 	out.WriteString("</code></pre>\n")
 }
-
 
 func (options *Html) BlockQuote(out *bytes.Buffer, text []byte) {
 	doubleSpace(out)
@@ -406,16 +405,18 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 		return
 	}
 
-    if options.flags&HTML_LINK_IMAGES != 0 {
-        out.WriteString(`<a href="`)
-        attrEscape(out, link)
-        out.WriteString(`">`)
-        if len(title) > 0 {
-            attrEscape(out, title)
+	if options.flags&HTML_LINK_IMAGES != 0 {
+		out.WriteString(`<a href="`)
+		attrEscape(out, link)
+		out.WriteString(`">`)
+		if len(title) > 0 {
+			attrEscape(out, title)
+		} else if len(alt) > 0 {
+			attrEscape(out, alt)
 		}
-        out.WriteString("</a>")
-        return
-    }
+		out.WriteString("</a>")
+		return
+	}
 
 	out.WriteString("<img src=\"")
 	attrEscape(out, link)
@@ -471,10 +472,10 @@ func (options *Html) RawHtmlTag(out *bytes.Buffer, text []byte) {
 	if options.flags&HTML_SKIP_HTML != 0 {
 		return
 	}
-    if options.flags&HTML_ESCAPE_HTML != 0 {
-        attrEscape(out, text)
-        return
-    }
+	if options.flags&HTML_ESCAPE_HTML != 0 {
+		attrEscape(out, text)
+		return
+	}
 	if options.flags&HTML_SKIP_STYLE != 0 && isHtmlTag(text, "style") {
 		return
 	}

--- a/html.go
+++ b/html.go
@@ -409,10 +409,13 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 		out.WriteString(`<a href="`)
 		attrEscape(out, link)
 		out.WriteString(`">`)
-		if len(title) > 0 {
+		switch {
+		case len(title) > 0:
 			attrEscape(out, title)
-		} else if len(alt) > 0 {
+		case len(alt) > 0:
 			attrEscape(out, alt)
+		default:
+			attrEscape(out, link)
 		}
 		out.WriteString("</a>")
 		return

--- a/html.go
+++ b/html.go
@@ -420,7 +420,8 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 		attrEscape(out, title)
 		out.WriteString(`">`)
 		attrEscape(out, title)
-		out.WriteString("</a>")
+		out.WriteString("</a")
+		out.WriteString(htmlClose)
 		return
 	}
 

--- a/inline_test.go
+++ b/inline_test.go
@@ -17,12 +17,10 @@ import (
 	"testing"
 )
 
-func runMarkdownInline(input string) string {
-	extensions := 0
+func runMarkdownInlineCustom(input string, extensions, htmlFlags int) string {
 	extensions |= EXTENSION_AUTOLINK
 	extensions |= EXTENSION_STRIKETHROUGH
 
-	htmlFlags := 0
 	htmlFlags |= HTML_USE_XHTML
 
 	renderer := HtmlRenderer(htmlFlags, "", "")
@@ -30,7 +28,15 @@ func runMarkdownInline(input string) string {
 	return string(Markdown([]byte(input), renderer, extensions))
 }
 
-func doTestsInline(t *testing.T, tests []string) {
+func runMarkdownInlineEscapeHTML(input string) string {
+	return runMarkdownInlineCustom(input, 0, HTML_ESCAPE_HTML)
+}
+
+func runMarkdownInline(input string) string {
+	return runMarkdownInlineCustom(input, 0, 0)
+}
+
+func doTestsInlineCustom(t *testing.T, tests []string, extensions, htmlFlags int) {
 	// catch and report panics
 	var candidate string
 	defer func() {
@@ -43,7 +49,7 @@ func doTestsInline(t *testing.T, tests []string) {
 		input := tests[i]
 		candidate = input
 		expected := tests[i+1]
-		actual := runMarkdownInline(candidate)
+		actual := runMarkdownInlineCustom(candidate, extensions, htmlFlags)
 		if actual != expected {
 			t.Errorf("\nInput   [%#v]\nExpected[%#v]\nActual  [%#v]",
 				candidate, expected, actual)
@@ -54,11 +60,15 @@ func doTestsInline(t *testing.T, tests []string) {
 			for start := 0; start < len(input); start++ {
 				for end := start + 1; end <= len(input); end++ {
 					candidate = input[start:end]
-					_ = runMarkdownInline(candidate)
+					_ = runMarkdownInlineCustom(candidate, extensions, htmlFlags)
 				}
 			}
 		}
 	}
+}
+
+func doTestsInline(t *testing.T, tests []string) {
+	doTestsInlineCustom(t, tests, 0, 0)
 }
 
 func TestEmphasis(t *testing.T) {
@@ -463,4 +473,21 @@ func TestAutoLink(t *testing.T) {
 			"http://new.com?q=&gt;&amp;etc</a></p>\n",
 	}
 	doTestsInline(t, tests)
+}
+
+func TestTagsEscapeHTML(t *testing.T) {
+	var tests = []string{
+		"a <span>tag</span>\n",
+		"<p>a &lt;span&gt;tag&lt;/span&gt;</p>\n",
+
+		"<span>tag</span>\n",
+		"<p>&lt;span&gt;tag&lt;/span&gt;</p>\n",
+
+		"<span>mismatch</spandex>\n",
+		"<p>&lt;span&gt;mismatch&lt;/spandex&gt;</p>\n",
+
+		"a <singleton /> tag\n",
+		"<p>a &lt;singleton /&gt; tag</p>\n",
+	}
+	doTestsInlineCustom(t, tests, 0, HTML_ESCAPE_HTML)
 }

--- a/inline_test.go
+++ b/inline_test.go
@@ -398,7 +398,7 @@ func TestInlineLinkedImage(t *testing.T) {
 		"![foo]()\n",
 		"<p>![foo]()</p>\n",
 	}
-	doTestsInlineCustom(t, tests, 0, HTML_LINK_IMAGES)
+	doTestsInlineCustom(t, tests, 0, HTML_REPLACE_IMAGES)
 }
 
 func TestReferenceLink(t *testing.T) {

--- a/inline_test.go
+++ b/inline_test.go
@@ -28,10 +28,6 @@ func runMarkdownInlineCustom(input string, extensions, htmlFlags int) string {
 	return string(Markdown([]byte(input), renderer, extensions))
 }
 
-func runMarkdownInlineEscapeHTML(input string) string {
-	return runMarkdownInlineCustom(input, 0, HTML_ESCAPE_HTML)
-}
-
 func runMarkdownInline(input string) string {
 	return runMarkdownInlineCustom(input, 0, 0)
 }
@@ -380,6 +376,29 @@ func TestInlineLink(t *testing.T) {
 		"<p><a href=\"/url/&amp;query\">link</a></p>\n",
 	}
 	doTestsInline(t, tests)
+}
+
+func TestInlineLinkedImage(t *testing.T) {
+	var tests = []string{
+		"![foo](/bar/)\n",
+		"<p><a href=\"/bar/\" title=\"foo\">foo</a>\n</p>\n",
+
+		"![foo with a title](/bar/ \"title\")\n",
+		"<p><a href=\"/bar/\" title=\"title\">title</a>\n</p>\n",
+
+		"![foo with a title](/bar/\t\"title\")\n",
+		"<p><a href=\"/bar/\" title=\"title\">title</a>\n</p>\n",
+
+		"![foo with a title](/bar/ \"title\"  )\n",
+		"<p><a href=\"/bar/\" title=\"title\">title</a>\n</p>\n",
+
+		"![foo with a title](/bar/ title with no quotes)\n",
+		"<p><a href=\"/bar/ title with no quotes\" title=\"foo with a title\">foo with a title</a>\n</p>\n",
+
+		"![foo]()\n",
+		"<p>![foo]()</p>\n",
+	}
+	doTestsInlineCustom(t, tests, 0, HTML_LINK_IMAGES)
 }
 
 func TestReferenceLink(t *testing.T) {


### PR DESCRIPTION
This patch adds two HTML options. Both have inline tests, and flags in the example `markdown` command. Check out the additions to `inline_test.go` to see expected output when using the options.
- `HTML_REPLACE_IMAGES`

This tag replaces images with text links to their sources. The link content is (depending on the strings' existence) either, the image's title, alttext, or source. Strings are checked in that order.

Use `markdown -img2link` to use this option in the example command.
- `HTML_ESCAPE_HTML`

This options runs block HTML, as well as raw tags, through attrEscape. Simple. Effectively, it's like `HTML_SKIP_HTML`. But, it's more direct in informing user's that raw HTML is not allowed.

use `markdown -htmlesc` to use this option in the example command.
