### PR TITLE
Fix up method documentation formatting for the BlockCodeGithub method.

### DIFF
--- a/html.go
+++ b/html.go
@@ -220,7 +220,7 @@ func (options *Html) BlockCodeNormal(out *bytes.Buffer, text []byte, lang string
 //
 //              <pre lang="LANG"><code>
 //              ...
-//              </pre></code>
+//              </code></pre>
 //
 // Unlike other parsers, we store the language identifier in the <pre>,
 // and don't let the user generate custom classes.


### PR DESCRIPTION
Java-style comment banners-of-stars don't work with go docs (either in godoc or go.pkgdoc.org).
