### PR TITLE
add extension to support one space indent and refactoring on some test cases

### DIFF
--- a/block.go
+++ b/block.go
@@ -1069,7 +1069,7 @@ gatherlines:
 		case p.isPrefixHeader(chunk):
 			// if the header is not indented, it is not nested in the list
 			// and thus ends the list
-			if containsBlankLine && indent < 4 {
+			if containsBlankLine && indent < ListIndentSpacesCount {
 				*flags |= LIST_ITEM_END_OF_LIST
 				break gatherlines
 			}
@@ -1078,7 +1078,7 @@ gatherlines:
 		// anything following an empty line is only part
 		// of this item if it is indented 4 spaces
 		// (regardless of the indentation of the beginning of the item)
-		case containsBlankLine && indent < 4:
+		case containsBlankLine && indent < ListIndentSpacesCount:
 			*flags |= LIST_ITEM_END_OF_LIST
 			break gatherlines
 

--- a/block_test.go
+++ b/block_test.go
@@ -348,9 +348,6 @@ func TestUnorderedList(t *testing.T) {
 		"*   Hello \n    Next line \n",
 		"<ul>\n<li>Hello\nNext line</li>\n</ul>\n",
 
-		"Paragraph\n* No linebreak\n",
-		"<p>Paragraph\n* No linebreak</p>\n",
-
 		"Paragraph\n\n* Linebreak\n",
 		"<p>Paragraph</p>\n\n<ul>\n<li>Linebreak</li>\n</ul>\n",
 
@@ -391,6 +388,9 @@ func TestUnorderedList(t *testing.T) {
 		"* List\n        extra indent, same paragraph\n",
 		"<ul>\n<li>List\n    extra indent, same paragraph</li>\n</ul>\n",
 
+		"* List\n\n    >indent quote\n",
+		"<ul>\n<li><p>List</p>\n\n<blockquote>\n<p>indent quote</p>\n</blockquote></li>\n</ul>\n",
+
 		"* List\n\n        code block\n",
 		"<ul>\n<li><p>List</p>\n\n<pre><code>code block\n</code></pre></li>\n</ul>\n",
 
@@ -400,7 +400,45 @@ func TestUnorderedList(t *testing.T) {
 		"* List\n\n    * sublist\n\n    normal text\n\n    * another sublist\n",
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li>sublist</li>\n</ul>\n\n<p>normal text</p>\n\n<ul>\n<li>another sublist</li>\n</ul></li>\n</ul>\n",
 	}
-	doTestsBlock(t, tests, 0)
+
+	var tests1 = append(tests, []string{
+		"*Hello\n",
+		"<p>*Hello</p>\n",
+
+		"Paragraph\n* No linebreak\n",
+		"<p>Paragraph\n* No linebreak</p>\n",
+	}...)
+	doTestsBlock(t, tests1, 0)
+
+	var tests2 = append(tests, []string{
+		"*Hello\n",
+		"<p>*Hello</p>\n",
+
+		"Paragraph\n* No linebreak\n",
+		"<p>Paragraph</p>\n\n<ul>\n<li>No linebreak</li>\n</ul>\n",
+	}...)
+	doTestsBlock(t, tests2, EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK)
+
+	var tests3 = append(tests, []string{
+		"* List\n\n 1 space indent paragraph\n",
+		"<ul>\n<li><p>List</p>\n\n<p>1 space indent paragraph</p></li>\n</ul>\n",
+
+		"* List\n\n  2 spaces indent paragraph\n",
+		"<ul>\n<li><p>List</p>\n\n<p>2 spaces indent paragraph</p></li>\n</ul>\n",
+
+		"* List\n\n   3 spaces indent paragraph\n",
+		"<ul>\n<li><p>List</p>\n\n<p>3 spaces indent paragraph</p></li>\n</ul>\n",
+
+		"* List\n\n >1 space indent quote\n",
+		"<ul>\n<li><p>List</p>\n\n<blockquote>\n<p>1 space indent quote</p>\n</blockquote></li>\n</ul>\n",
+
+		"* List\n\n  >2 spaces indent quote\n",
+		"<ul>\n<li><p>List</p>\n\n<blockquote>\n<p>2 spaces indent quote</p>\n</blockquote></li>\n</ul>\n",
+
+		"* List\n\n   >3 spaces indent quote\n",
+		"<ul>\n<li><p>List</p>\n\n<blockquote>\n<p>3 spaces indent quote</p>\n</blockquote></li>\n</ul>\n",
+	}...)
+	doTestsBlock(t, tests3, EXTENSION_ONE_SPACE_INDENT)
 }
 
 func TestOrderedList(t *testing.T) {
@@ -432,8 +470,6 @@ func TestOrderedList(t *testing.T) {
 		"1.  Hello \n    Next line \n",
 		"<ol>\n<li>Hello\nNext line</li>\n</ol>\n",
 
-		"Paragraph\n1. No linebreak\n",
-		"<p>Paragraph\n1. No linebreak</p>\n",
 
 		"Paragraph\n\n1. Linebreak\n",
 		"<p>Paragraph</p>\n\n<ol>\n<li>Linebreak</li>\n</ol>\n",
@@ -496,7 +532,45 @@ func TestOrderedList(t *testing.T) {
 		"1. numbers\n1. are ignored\n",
 		"<ol>\n<li>numbers</li>\n<li>are ignored</li>\n</ol>\n",
 	}
-	doTestsBlock(t, tests, 0)
+
+	var tests1 = append(tests, []string{
+		"1.Hello\n",
+		"<p>1.Hello</p>\n",
+
+		"Paragraph\n1. No linebreak\n",
+		"<p>Paragraph\n1. No linebreak</p>\n",
+	}...)
+	doTestsBlock(t, tests1, 0)
+
+	var tests2 = append(tests, []string{
+		"1.Hello\n",
+		"<p>1.Hello</p>\n",
+
+		"Paragraph\n1. No linebreak\n",
+		"<p>Paragraph</p>\n\n<ol>\n<li>No linebreak</li>\n</ol>\n",
+	}...)
+	doTestsBlock(t, tests2, EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK)
+
+	var tests3 = append(tests, []string{
+		"1. List\n\n 1 space indent paragraph\n",
+		"<ol>\n<li><p>List</p>\n\n<p>1 space indent paragraph</p></li>\n</ol>\n",
+
+		"1. List\n\n  2 spaces indent paragraph\n",
+		"<ol>\n<li><p>List</p>\n\n<p>2 spaces indent paragraph</p></li>\n</ol>\n",
+
+		"1. List\n\n   3 spaces indent paragraph\n",
+		"<ol>\n<li><p>List</p>\n\n<p>3 spaces indent paragraph</p></li>\n</ol>\n",
+
+		"1. List\n\n >1 space indent quote\n",
+		"<ol>\n<li><p>List</p>\n\n<blockquote>\n<p>1 space indent quote</p>\n</blockquote></li>\n</ol>\n",
+
+		"1. List\n\n  >2 spaces indent quote\n",
+		"<ol>\n<li><p>List</p>\n\n<blockquote>\n<p>2 spaces indent quote</p>\n</blockquote></li>\n</ol>\n",
+
+		"1. List\n\n   >3 spaces indent quote\n",
+		"<ol>\n<li><p>List</p>\n\n<blockquote>\n<p>3 spaces indent quote</p>\n</blockquote></li>\n</ol>\n",
+	}...)
+	doTestsBlock(t, tests3, EXTENSION_ONE_SPACE_INDENT)
 }
 
 func TestPreformattedHtml(t *testing.T) {

--- a/markdown.go
+++ b/markdown.go
@@ -38,7 +38,8 @@ const (
 	EXTENSION_HARD_LINE_BREAK                        // translate newlines into line breaks
 	EXTENSION_TAB_SIZE_EIGHT                         // expand tabs to eight spaces instead of four
 	EXTENSION_FOOTNOTES                              // Pandoc-style footnotes
-	EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK             // No need to insert an empty line to start a (code, quote, order list, unorder list)block
+	EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK             // no need to insert an empty line to start a (code, quote, order list, unorder list)block
+	EXTENSION_ONE_SPACE_INDENT                       // allow indent for list item when there is 1 or spaces
 )
 
 // These are the possible flag values for the link renderer.
@@ -115,6 +116,9 @@ var blockTags = map[string]bool{
 	"progress":   true,
 	"figcaption": true,
 }
+
+// The default indent is 4 spaces
+var ListIndentSpacesCount = 4
 
 // Renderer is the rendering interface.
 // This is mostly of interest if you are implementing a new rendering format.
@@ -256,6 +260,10 @@ func Markdown(input []byte, renderer Renderer, extensions int) []byte {
 	// no point in parsing if we can't render
 	if renderer == nil {
 		return nil
+	}
+
+	if extensions&EXTENSION_ONE_SPACE_INDENT != 0 {
+		ListIndentSpacesCount = 1
 	}
 
 	// fill in the render structure

--- a/upskirtref_test.go
+++ b/upskirtref_test.go
@@ -76,7 +76,6 @@ func TestReference(t *testing.T) {
 		"Blockquotes with code blocks",
 		"Code Blocks",
 		"Code Spans",
-		"Hard-wrapped paragraphs with list-like lines",
 		"Horizontal rules",
 		"Inline HTML (Advanced)",
 		"Inline HTML (Simple)",
@@ -93,33 +92,14 @@ func TestReference(t *testing.T) {
 		"Tabs",
 		"Tidyness",
 	}
-	doTestsReference(t, files, 0)
-}
 
-func TestReference_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
-	files := []string{
-		"Amps and angle encoding",
-		"Auto links",
-		"Backslash escapes",
-		"Blockquotes with code blocks",
-		"Code Blocks",
-		"Code Spans",
+	var files1 = append(files, []string{
+		"Hard-wrapped paragraphs with list-like lines",
+	}...)
+	doTestsReference(t, files1, 0)
+
+	var files2 = append(files, []string{
 		"Hard-wrapped paragraphs with list-like lines no empty line before block",
-		"Horizontal rules",
-		"Inline HTML (Advanced)",
-		"Inline HTML (Simple)",
-		"Inline HTML comments",
-		"Links, inline style",
-		"Links, reference style",
-		"Links, shortcut references",
-		"Literal quotes in titles",
-		"Markdown Documentation - Basics",
-		"Markdown Documentation - Syntax",
-		"Nested blockquotes",
-		"Ordered and unordered lists",
-		"Strong and em together",
-		"Tabs",
-		"Tidyness",
-	}
-	doTestsReference(t, files, EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK)
+	}...)
+	doTestsReference(t, files2, EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK)
 }


### PR DESCRIPTION
Sometimes I think one space indent will be more convenient than 4 spaces.

Actually many other implementations allows one space indentation.
It was a [corner case](http://johnmacfarlane.net/babelmark2/faq.html#what-are-some-big-questions-that-the-markdown-spec-does-not-answer) between implementations and the spec.

I think it will be nice if blackfriday support this option?
