### PR TITLE
allow \~ to escape as ~

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -549,7 +549,7 @@ func leftAngle(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 }
 
 // '\\' backslash escape
-var escapeChars = []byte("\\`*_{}[]()#+-.!:|&<>")
+var escapeChars = []byte("\\`*_{}[]()#+-.!:|&<>~")
 
 func escape(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	data = data[offset:]

--- a/upskirtref/Backslash escapes.html
+++ b/upskirtref/Backslash escapes.html
@@ -32,6 +32,8 @@
 
 <p>Minus: -</p>
 
+<p>Tilde: ~</p>
+
 <p>These should not, because they occur within a code block:</p>
 
 <pre><code>Backslash: \\
@@ -65,6 +67,8 @@ Bang: \!
 Plus: \+
 
 Minus: \-
+
+Tilde: \~
 </code></pre>
 
 <p>Nor should these, which occur in code spans:</p>
@@ -100,6 +104,8 @@ Minus: \-
 <p>Plus: <code>\+</code></p>
 
 <p>Minus: <code>\-</code></p>
+
+<p>Tilde: <code>\~</code></p>
 
 <p>These should get escaped, even though they're matching pairs for
 other Markdown constructs:</p>

--- a/upskirtref/Backslash escapes.text
+++ b/upskirtref/Backslash escapes.text
@@ -32,6 +32,8 @@ Plus: \+
 
 Minus: \-
 
+Tilde: \~
+
 
 
 These should not, because they occur within a code block:
@@ -68,6 +70,8 @@ These should not, because they occur within a code block:
 
 	Minus: \-
 
+	Tilde: \~
+
 
 Nor should these, which occur in code spans:
 
@@ -102,6 +106,8 @@ Bang: `\!`
 Plus: `\+`
 
 Minus: `\-`
+
+Tilde: `\~`
 
 
 These should get escaped, even though they're matching pairs for


### PR DESCRIPTION
Hi, I think it will be cool if the `\~` can be escaped as `~` too.
and it makes no much sense to add an extension for that. So I just simply add it in the escapeChars set.
