### PR TITLE
add HTML_NOFOLLOW_LINKS

### DIFF
--- a/html.go
+++ b/html.go
@@ -30,6 +30,7 @@ const (
 	HTML_SKIP_LINKS                           // skip all links
 	HTML_SKIP_SCRIPT                          // skip embedded <script> elements
 	HTML_SAFELINK                             // only link to trusted protocols
+	HTML_NOFOLLOW_LINKS                       // only link with rel="nofollow"
 	HTML_TOC                                  // generate a table of contents
 	HTML_OMIT_CONTENTS                        // skip the main contents (for a standalone table of contents)
 	HTML_COMPLETE_PAGE                        // generate a complete HTML page
@@ -498,6 +499,9 @@ func (options *Html) Link(out *bytes.Buffer, link []byte, title []byte, content 
 	if len(title) > 0 {
 		out.WriteString("\" title=\"")
 		attrEscape(out, title)
+	}
+	if options.flags&HTML_NOFOLLOW_LINKS != 0 {
+		out.WriteString("\" rel=\"nofollow")
 	}
 	out.WriteString("\">")
 	out.Write(content)

--- a/inline_test.go
+++ b/inline_test.go
@@ -421,6 +421,14 @@ func TestInlineLink(t *testing.T) {
 	doTestsInline(t, tests)
 }
 
+func TestNofollowLink(t *testing.T) {
+	var tests = []string{
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\" rel=\"nofollow\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, tests, 0, HTML_SAFELINK|HTML_NOFOLLOW_LINKS)
+}
+
 func TestSafeInlineLink(t *testing.T) {
 	var tests = []string{
 		"[foo](/bar/)\n",


### PR DESCRIPTION
If one of the target uses of blackfriday is formatting and displaying untrusted user data, I think having the ability to force rel="nofollow" into the links is probably important for spam reduction purposes:

https://support.google.com/webmasters/answer/96569?hl=en

http://www.searchenginejournal.com/all-wikipedia-links-are-now-nofollow/4288/
