### PR TITLE
Explicit return byte array at end of function.

### DIFF
--- a/html.go
+++ b/html.go
@@ -818,9 +818,8 @@ func sanitizeHtml(html []byte) []byte {
 func sanitizeTag(tag []byte) []byte {
 	if tagWhitelist.Match(tag) || anchorClean.Match(tag) || imgClean.Match(tag) {
 		return tag
-	} else {
-		return []byte("")
 	}
+	return []byte("")
 }
 
 func skipUntilChar(text []byte, start int, char byte) int {


### PR DESCRIPTION
Very handy markdown library! However I had a problem when importing the latest version:
''src/github.com/russross/blackfriday/html.go:818: function ends without a return statement''

By explicit return a new byte array unless if hits, fixes this issue.
Edit: seems that this constraint is removed in go 1.1 (I currently run 1.0.2), however I think the fix should be included for backwards compatibility. :-)
