### PR TITLE
Don't expand tabs inside fenced code blocks.

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -638,7 +638,7 @@ func TestPreformattedHtmlLax(t *testing.T) {
 func TestFencedCodeBlock(t *testing.T) {
 	var tests = []string{
 		"``` go\nfunc foo() bool {\n\treturn true;\n}\n```\n",
-		"<pre><code class=\"go\">func foo() bool {\n    return true;\n}\n</code></pre>\n",
+		"<pre><code class=\"go\">func foo() bool {\n\treturn true;\n}\n</code></pre>\n",
 
 		"``` c\n/* special & char < > \" escaping */\n```\n",
 		"<pre><code class=\"c\">/* special &amp; char &lt; &gt; &quot; escaping */\n</code></pre>\n",
@@ -978,7 +978,7 @@ func TestOrderedList_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 func TestFencedCodeBlock_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 	var tests = []string{
 		"``` go\nfunc foo() bool {\n\treturn true;\n}\n```\n",
-		"<pre><code class=\"go\">func foo() bool {\n    return true;\n}\n</code></pre>\n",
+		"<pre><code class=\"go\">func foo() bool {\n\treturn true;\n}\n</code></pre>\n",
 
 		"``` c\n/* special & char < > \" escaping */\n```\n",
 		"<pre><code class=\"c\">/* special &amp; char &lt; &gt; &quot; escaping */\n</code></pre>\n",

--- a/markdown.go
+++ b/markdown.go
@@ -343,7 +343,11 @@ func firstPass(p *parser, input []byte) []byte {
 
 			// add the line body if present
 			if end > beg {
-				expandTabs(&out, input[beg:end], tabSize)
+				if end < lastFencedCodeBlockEnd { // Do not expand tabs while inside fenced code blocks.
+					out.Write(input[beg:end])
+				} else {
+					expandTabs(&out, input[beg:end], tabSize)
+				}
 			}
 			out.WriteByte('\n')
 


### PR DESCRIPTION
Still do normalize newlines inside fenced code blocks.

```
$ go test github.com/shurcooL/blackfriday
ok      github.com/shurcooL/blackfriday 19.893s
```

Fixes #57.
