### PR TITLE
Add table tags to the whitelist.

### DIFF
--- a/html.go
+++ b/html.go
@@ -78,8 +78,15 @@ var (
 		"tbody",
 		
 	}
+	
+	alignments = []string{
+		"left",
+		"right",
+		"center",
+	}
+
 	urlRe        = `((https?|ftp):\/\/|\/)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)]+`
-	tagWhitelist = regexp.MustCompile(`^(<\/?(` + strings.Join(tags, "|") + `)>|<(br|hr)\s?\/?>)$`)
+	tagWhitelist = regexp.MustCompile(`^(<\/?(` + strings.Join(tags, "|") + `)(\salign="(` + strings.Join(alignments, "|") + `)")?>|<(br|hr)\s?\/?>)$`)
 	anchorClean  = regexp.MustCompile(`^(<a\shref="` + urlRe + `"(\stitle="[^"<>]+")?\s?>|<\/a>)$`)
 	imgClean     = regexp.MustCompile(`^(<img\ssrc="` + urlRe + `"(\swidth="\d{1,3}")?(\sheight="\d{1,3}")?(\salt="[^"<>]*")?(\stitle="[^"<>]*")?\s?\/?>)$`)
 	// TODO: improve this regexp to catch all possible entities:


### PR DESCRIPTION
Fixing:
https://github.com/russross/blackfriday/commit/55cd82008e9b35b9a03a80e06d5a4c4601320211

This commit introduced a html tag whitelist which does not include any table tags (`<td>,<tr>,<thead>`...). Therefore even tables the markdown parser itself generated will be removed.
