### PR TITLE
Fix fenced code extension modifying data beyond slice

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -332,7 +332,7 @@ func firstPass(p *parser, input []byte) []byte {
 				// when last line was none blank and a fenced code block comes after
 				if beg >= lastFencedCodeBlockEnd {
 					// tmp var so we don't modify beyond bounds of `input`
-					var tmp = make([]byte, len(input[beg:]))
+					var tmp = make([]byte, len(input[beg:]), len(input[beg:]) + 1)
 					copy(tmp, input[beg:])
 					if i := p.fencedCode(&out, append(tmp, '\n'), false); i > 0 {
 						if !lastLineWasBlank {


### PR DESCRIPTION
I had an issue whereby I was feeding an array slice into blackfriday, and it was modifying data beyond the end of the slice by adding a `\n` and in the process overwriting the data that was already there.

Turns out the `append` here was responsible, so I've changed this to use a temporary variable instead.
