### PR TITLE
Avoid raw mode parsing so that tags like <script> don't cause escaping

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -107,6 +107,10 @@ func sanitizeHtmlSafe(input []byte) []byte {
 			} else {
 				wr.WriteString(html.EscapeString(string(tokenizer.Raw())))
 			}
+			// Make sure that tags like <script> that switch the parser into raw mode
+			// do not destroy the parse mode for following HTML text (the point is to
+			// escape them anyway). For that, switch off raw mode in the tokenizer.
+			tokenizer.NextIsNotRawText()
 		case html.EndTagToken:
 			// Whitelisted tokens can be written in raw.
 			tag, _ := tokenizer.TagName()


### PR DESCRIPTION
Certain tags like <script> but also &lt;title> and others switch an HTML5 parser
into raw mode, which causes the rest of the HTML string to be always parsed as
text, including any elements or entities that we do want to support (e.g. &lt;p>).

As we're going to escape any of the raw text elements anyway (it's e.g. script,
style, title, xmp, noframes, and a couple of others) we can just switch of raw
text parsing by disabling it after each starting tag.
