### PR TITLE
Sanitize shouldn't filter out URLs without protocol.

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -92,7 +92,7 @@ func sanitizeHtmlSafe(input []byte) []byte {
 						// protocol checking, do so and strip it if it's not known to be safe.
 						tagProtocolAttrs, ok := protocolAttrs[tagName]
 						if ok && tagProtocolAttrs[attrName] {
-							if !protocolAllowed(val) {
+							if !isRelativeLink(val) && !protocolAllowed(val) {
 								continue
 							}
 						}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -80,7 +80,7 @@ func TestSanitizeRawHtmlTag(t *testing.T) {
 		"<p><img></p>\n",
 
 		`<IMG SRC=# onmouseover="alert('xxs')">`,
-		"<p><img></p>\n",
+		"<p><img src=\"#\"></p>\n",
 
 		`<IMG SRC= onmouseover="alert('xxs')">`,
 		"<p><img></p>\n",
@@ -192,6 +192,8 @@ func TestSanitizeInlineLink(t *testing.T) {
 	tests := []string{
 		"[link](javascript:evil)",
 		"<p><a>link</a></p>\n",
+                "[link](/abc)",
+                "<p><a href=\"/abc\">link</a></p>\n",
 	}
 	doTestsSanitize(t, tests)
 }


### PR DESCRIPTION
Fix for issue #81.

Sanitize was deleting links such as `[link](/page.html)` since they did not have a protocol. This doesn't seem like desired behavior.

Please note the test changes, specifically that `src=#` is no longer removed with this change. I'm not sure if that's ok or not, so another case may need to be added for that. I also added a test case for relative links and tested against my own code to verify.
