### PR TITLE
Adding flag for templates

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -618,6 +618,36 @@ func entity(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	return end
 }
 
+// pass through any template actions - {{action}}
+func templateAction(p *parser, out *bytes.Buffer, data []byte, offset int) int {
+	data = data[offset:]
+	
+	// return if it doesn't start with {{
+	if data[1] != '{' {
+		return 0
+	}
+	
+	// return if there isn't enough characters for an empty action - {{}}
+	if len(data) < 4 {
+		return 0
+	}
+	
+	// find the closing }}
+	i := 2
+	for data[i] != '}' || data[i+1] != '}' {
+		i++
+		
+		// return if the data end before the closing }}
+		if i + 1 == len(data) {
+			return 0
+		}
+	}
+	i += 2
+	
+	out.Write(data[0:i])
+	return i
+}
+
 func linkEndsWithEntity(data []byte, linkEnd int) bool {
 	entityRanges := htmlEntity.FindAllIndex(data[:linkEnd], -1)
 	if entityRanges != nil && entityRanges[len(entityRanges)-1][1] == linkEnd {

--- a/markdown.go
+++ b/markdown.go
@@ -40,6 +40,7 @@ const (
 	EXTENSION_FOOTNOTES                              // Pandoc-style footnotes
 	EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK             // No need to insert an empty line to start a (code, quote, order list, unorder list)block
 	EXTENSION_HEADER_IDS                             // specify header IDs  with {#id}
+	EXTENSION_PASSTHROUGH_TEMPLATE_ACTION            // pass through any template actions specified with {{action}}
 )
 
 // These are the possible flag values for the link renderer.
@@ -285,6 +286,10 @@ func Markdown(input []byte, renderer Renderer, extensions int) []byte {
 	p.inlineCallback['<'] = leftAngle
 	p.inlineCallback['\\'] = escape
 	p.inlineCallback['&'] = entity
+	if extensions&EXTENSION_PASSTHROUGH_TEMPLATE_ACTION != 0 {
+		p.inlineCallback['{'] = templateAction
+	}
+	
 
 	if extensions&EXTENSION_AUTOLINK != 0 {
 		p.inlineCallback[':'] = autoLink


### PR DESCRIPTION
Added extension flag EXTENSION_PASSTHROUGH_TEMPLATE_ACTION. If set, an inline function, templateAction, is added that ignores any text in between `{{` and `}}`. This is useful for `text/template` and `html/template`.
