### PR TITLE
Add a reference to github_flavored_markdown in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,19 @@ implements the following extensions:
     <sup>4</sup>&frasl;<sub>5</sub>.
 
 
-Non-HTML output
+Other renderers
 ---------------
 
 Blackfriday is structured to allow alternative rendering engines. Here
 are a few of note:
+
+*   [github_flavored_markdown](https://godoc.org/github.com/shurcooL/go/github_flavored_markdown):
+    provides a GitHub Flavored Markdown renderer with fenced code block
+    highlighting, clickable header anchor links.
+
+    It's not customizable, and its goal is to produce HTML output
+    equivalent to the [GitHub Markdown API endpoint](https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode),
+    except the rendering is performed locally.
 
 *   [markdownfmt](https://github.com/shurcooL/markdownfmt): like gofmt,
     but for markdown.


### PR DESCRIPTION
As I mentioned at https://github.com/russross/blackfriday/issues/91#issuecomment-48074453, I think it's best to keep the GitHub Flavored Markdown rendering logic separate from the general, customizable parsing offered by blackfriday.

This PR adds a reference to the GFM renderer that's based on blackfriday.

It is my understanding that @russross would likely be in agreement with this approach, per https://github.com/russross/blackfriday/issues/80#issuecomment-43126205.
