### PR TITLE
Improve parser to detect LineBreak independently of renderer.

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -166,8 +166,10 @@ func lineBreak(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	}
 	out.Truncate(eol)
 
+	precededByTwoSpaces := offset >= 2 && data[offset-2] == ' ' && data[offset-1] == ' '
+
 	// should there be a hard line break here?
-	if p.flags&EXTENSION_HARD_LINE_BREAK == 0 && end-eol < 2 {
+	if p.flags&EXTENSION_HARD_LINE_BREAK == 0 && !precededByTwoSpaces {
 		return 0
 	}
 


### PR DESCRIPTION
When checking if it's a newline preceeded by two spaces, look at the input data rather than the output, since the output depends on the renderer implementation.

Partially fixes #106.

Tests pass.

It should have no effect on the default HTML and Latex parsers, since their `NormalText` method preserves the whitespace. But for 3rd party renderers that do not preserve whitespace, this will fix the problem where `LineBreak` method was not being called despite input Markdown document having a line break (in the form of a newline preceeded by two spaces).
