### PR TITLE
Make sure relative URLs are preserved

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -42,7 +42,7 @@ func doLinkTestsInline(t *testing.T, tests []string) {
 	params := HtmlRendererParameters{AbsolutePrefix: prefix}
 	transformTests := transformLinks(tests, prefix)
 	doTestsInlineParam(t, transformTests, 0, 0, params)
-	doTestsInlineParam(t, transformTests, 0, commonHtmlFlags(), params)
+	doTestsInlineParam(t, transformTests, 0, commonHtmlFlags, params)
 }
 
 func doSafeTestsInline(t *testing.T, tests []string) {

--- a/markdown.go
+++ b/markdown.go
@@ -41,6 +41,21 @@ const (
 	EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK             // No need to insert an empty line to start a (code, quote, order list, unorder list)block
 	EXTENSION_HEADER_IDS                             // specify header IDs  with {#id}
 	EXTENSION_TITLEBLOCK                             // Titleblock ala pandoc
+
+	commonHtmlFlags = 0 |
+		HTML_USE_XHTML |
+		HTML_USE_SMARTYPANTS |
+		HTML_SMARTYPANTS_FRACTIONS |
+		HTML_SMARTYPANTS_LATEX_DASHES
+
+	commonExtensions = 0 |
+		EXTENSION_NO_INTRA_EMPHASIS |
+		EXTENSION_TABLES |
+		EXTENSION_FENCED_CODE |
+		EXTENSION_AUTOLINK |
+		EXTENSION_STRIKETHROUGH |
+		EXTENSION_SPACE_HEADERS |
+		EXTENSION_HEADER_IDS
 )
 
 // These are the possible flag values for the link renderer.
@@ -212,27 +227,6 @@ func MarkdownBasic(input []byte) []byte {
 	return Markdown(input, renderer, extensions)
 }
 
-func commonHtmlFlags() int {
-	htmlFlags := 0
-	htmlFlags |= HTML_USE_XHTML
-	htmlFlags |= HTML_USE_SMARTYPANTS
-	htmlFlags |= HTML_SMARTYPANTS_FRACTIONS
-	htmlFlags |= HTML_SMARTYPANTS_LATEX_DASHES
-	return htmlFlags
-}
-
-func commonExtensions() int {
-	extensions := 0
-	extensions |= EXTENSION_NO_INTRA_EMPHASIS
-	extensions |= EXTENSION_TABLES
-	extensions |= EXTENSION_FENCED_CODE
-	extensions |= EXTENSION_AUTOLINK
-	extensions |= EXTENSION_STRIKETHROUGH
-	extensions |= EXTENSION_SPACE_HEADERS
-	extensions |= EXTENSION_HEADER_IDS
-	return extensions
-}
-
 // Call Markdown with most useful extensions enabled
 // MarkdownCommon is a convenience function for simple rendering.
 // It processes markdown input with common extensions enabled, including:
@@ -254,8 +248,8 @@ func commonExtensions() int {
 // * Custom Header IDs
 func MarkdownCommon(input []byte) []byte {
 	// set up the HTML renderer
-	renderer := HtmlRenderer(commonHtmlFlags(), "", "")
-	return Markdown(input, renderer, commonExtensions())
+	renderer := HtmlRenderer(commonHtmlFlags, "", "")
+	return Markdown(input, renderer, commonExtensions)
 }
 
 // Markdown is the main rendering function.


### PR DESCRIPTION
Add tests to make sure we don't break relative URLs again.
Extracted common html flags and common extensions for easy access from
tests.

Closes issue #104, which was fixed as a side effect of cf6bfc9.
