### PR TITLE
Prevent header collisions on generation.

### DIFF
--- a/block.go
+++ b/block.go
@@ -15,7 +15,7 @@ package blackfriday
 
 import (
 	"bytes"
-	"unicode"
+	"github.com/shurcooL/go/github_flavored_markdown/sanitized_anchor_name"
 )
 
 // Parse block-level data.
@@ -227,7 +227,7 @@ func (p *parser) prefixHeader(out *bytes.Buffer, data []byte) int {
 	}
 	if end > i {
 		if id == "" && p.flags&EXTENSION_AUTO_HEADER_IDS != 0 {
-			id = createSanitizedAnchorName(string(data[i:end]))
+			id = sanitized_anchor_name.Create(string(data[i:end]))
 		}
 		work := func() bool {
 			p.inline(out, data[i:end])
@@ -1276,7 +1276,7 @@ func (p *parser) paragraph(out *bytes.Buffer, data []byte) int {
 
 				id := ""
 				if p.flags&EXTENSION_AUTO_HEADER_IDS != 0 {
-					id = createSanitizedAnchorName(string(data[prev:eol]))
+					id = sanitized_anchor_name.Create(string(data[prev:eol]))
 				}
 
 				p.r.Header(out, work, level, id)
@@ -1324,17 +1324,4 @@ func (p *parser) paragraph(out *bytes.Buffer, data []byte) int {
 
 	p.renderParagraph(out, data[:i])
 	return i
-}
-
-func createSanitizedAnchorName(text string) string {
-	var anchorName []rune
-	for _, r := range []rune(text) {
-		switch {
-		case r == ' ':
-			anchorName = append(anchorName, '-')
-		case unicode.IsLetter(r) || unicode.IsNumber(r):
-			anchorName = append(anchorName, unicode.ToLower(r))
-		}
-	}
-	return string(anchorName)
 }

--- a/block_test.go
+++ b/block_test.go
@@ -275,8 +275,25 @@ func TestPrefixAutoHeaderIdExtension(t *testing.T) {
 		"*   List\n    * Nested list\n    # Nested header\n",
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li><p>Nested list</p>\n\n" +
 			"<h1 id=\"nested-header\">Nested header</h1></li>\n</ul></li>\n</ul>\n",
+
+		"# Header\n\n# Header\n",
+		"<h1 id=\"header\">Header</h1>\n\n<h1 id=\"header-1\">Header</h1>\n",
+
+		"# Header 1\n\n# Header 1",
+		"<h1 id=\"header-1\">Header 1</h1>\n\n<h1 id=\"header-1-1\">Header 1</h1>\n",
+
+		"# Header\n\n# Header 1\n\n# Header\n\n# Header",
+		"<h1 id=\"header\">Header</h1>\n\n<h1 id=\"header-1\">Header 1</h1>\n\n<h1 id=\"header-1-1\">Header</h1>\n\n<h1 id=\"header-1-2\">Header</h1>\n",
 	}
 	doTestsBlock(t, tests, EXTENSION_AUTO_HEADER_IDS)
+}
+
+func TestPrefixMultipleHeaderExtensions(t *testing.T) {
+	var tests = []string{
+		"# Header\n\n# Header {#header}\n\n# Header 1",
+		"<h1 id=\"header\">Header</h1>\n\n<h1 id=\"header-1\">Header</h1>\n\n<h1 id=\"header-1-1\">Header 1</h1>\n",
+	}
+	doTestsBlock(t, tests, EXTENSION_AUTO_HEADER_IDS|EXTENSION_HEADER_IDS)
 }
 
 func TestUnderlineHeaders(t *testing.T) {
@@ -369,6 +386,12 @@ func TestUnderlineHeadersAutoIDs(t *testing.T) {
 
 		"Double underline\n=====\n=====\n",
 		"<h1 id=\"double-underline\">Double underline</h1>\n\n<p>=====</p>\n",
+
+		"Header\n======\n\nHeader\n======\n",
+		"<h1 id=\"header\">Header</h1>\n\n<h1 id=\"header-1\">Header</h1>\n",
+
+		"Header 1\n========\n\nHeader 1\n========\n",
+		"<h1 id=\"header-1\">Header 1</h1>\n\n<h1 id=\"header-1-1\">Header 1</h1>\n",
 	}
 	doTestsBlock(t, tests, EXTENSION_AUTO_HEADER_IDS)
 }


### PR DESCRIPTION
> This is the original description of the pull request. For the updated version which is less naive and more robust, please see [this comment](https://github.com/russross/blackfriday/pull/126#issuecomment-64109421).

The automatic header ID generation code that I submitted (#125) has a subtle bug where it will use the same ID for two headers that are identical. In the case below, both headers will be rendered as `<h1 id="header">Header</h1>`.

``` markdown
    # Header
    # Header
    # Header
```

This change is a relatively naive approach that uses an incrementing counter for cases like this to prevent header collision (resulting in `header`, `header-1`, and `header-2`). This will not prevent a collision like this:

``` markdown
    # Header
    # Header 1
    # Header
```

This could be prevented by a somewhat smarter approach that appends a suffix (like `-1`) to each collision (resulting in `header`, `header-1`, `header-1-1`), but that feels a bit wrong and the implementation is heavyweight in two ways:
1. The `parser.headers` would be changed from `map[string]int` to `map[string]bool`, and would grow larger for _each_ header that collides, because each of the forms `header`, `header-1`, and `header-1-1` would be put into `parser.headers`.
2. `parser.createSanitizedAnchorName` would need to be modified to be something like what follows. (The code here is untested.)

``` go
func (p *parser) createSanitizedAnchorName(text string) string {
  var anchorName []rune
  for _, r := range []rune(text) {
    switch {
    case r == ' ':
      anchorName = append(anchorName, '-')
    case unicode.IsLetter(r) || unicode.IsNumber(r):
      anchorName = append(anchorName, unicode.ToLower(r))
    }
  }

  return ensureUniqueAnchor(string(anchorName))
}

func (p *parser) ensureUniqueAnchor(anchor string) string {
  for _, found := p.headers[anchor]; found; found = p.headers[anchor] {
    anchor = anchor + "-1";
  }

  p.headers[anchor] = true

  return anchor
}
```
