### PR TITLE
Add possibility for HTML tags to contain Markdown text.

### DIFF
--- a/block.go
+++ b/block.go
@@ -487,11 +487,12 @@ func (p *parser) htmlFindTag(data []byte) (string, int, bool, bool) {
 		return "", 0, false, false
 	}
 
-	for data[i] != '>' {
+	// look up end of tag
+	for i < len(data) && data[i] != '>' {
 		i++
 	}
 
-	// dirty way of finding out if inside is markdown or not
+	// dirty way of finding out if tag has markdown="1" attribute
 	// TODO: do this in a clean way, with real HTML tag parsing
 	parse_inside := bytes.Contains(data[:i], []byte("markdown=\"1\""))
 


### PR DESCRIPTION
For instance, the following can now be written:

```
<div class="my_class" markdown="1">
- Item 1
- Item 2
- Item 3
</div>
```

Note: this is not done very cleanly, feel free to change it in a way that better suits the design of the software.
