### PR TITLE
Minor cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Build Status](https://travis-ci.org/russross/blackfriday.svg?branch=master)](https://travis-ci.org/russross/blackfriday)
-
-Blackfriday
+Blackfriday [![Build Status](https://travis-ci.org/russross/blackfriday.svg?branch=master)](https://travis-ci.org/russross/blackfriday)
 ===========
 
 Blackfriday is a [Markdown][1] processor implemented in [Go][2]. It
@@ -231,7 +229,6 @@ Todo
 ----
 
 *   More unit testing
-*   Markdown pretty-printer output engine
 *   Improve unicode support. It does not understand all unicode
     rules (about what constitutes a letter, a punctuation symbol,
     etc.), so it may fail to detect word boundaries correctly in
@@ -245,19 +242,19 @@ Blackfriday is distributed under the Simplified BSD License:
 
 > Copyright © 2011 Russ Ross
 > All rights reserved.
-> 
+>
 > Redistribution and use in source and binary forms, with or without
 > modification, are permitted provided that the following conditions
 > are met:
-> 
+>
 > 1.  Redistributions of source code must retain the above copyright
 >     notice, this list of conditions and the following disclaimer.
-> 
+>
 > 2.  Redistributions in binary form must reproduce the above
 >     copyright notice, this list of conditions and the following
 >     disclaimer in the documentation and/or other materials provided with
 >     the distribution.
-> 
+>
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 > "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 > LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS

--- a/block.go
+++ b/block.go
@@ -15,6 +15,7 @@ package blackfriday
 
 import (
 	"bytes"
+
 	"github.com/shurcooL/go/github_flavored_markdown/sanitized_anchor_name"
 )
 

--- a/html.go
+++ b/html.go
@@ -25,22 +25,22 @@ import (
 
 // Html renderer configuration options.
 const (
-	HTML_SKIP_HTML                = 1 << iota // skip preformatted HTML blocks
-	HTML_SKIP_STYLE                           // skip embedded <style> elements
-	HTML_SKIP_IMAGES                          // skip embedded images
-	HTML_SKIP_LINKS                           // skip all links
-	HTML_SAFELINK                             // only link to trusted protocols
-	HTML_NOFOLLOW_LINKS                       // only link with rel="nofollow"
-	HTML_HREF_TARGET_BLANK                    // add a blank target
-	HTML_TOC                                  // generate a table of contents
-	HTML_OMIT_CONTENTS                        // skip the main contents (for a standalone table of contents)
-	HTML_COMPLETE_PAGE                        // generate a complete HTML page
-	HTML_USE_XHTML                            // generate XHTML output instead of HTML
-	HTML_USE_SMARTYPANTS                      // enable smart punctuation substitutions
-	HTML_SMARTYPANTS_FRACTIONS                // enable smart fractions (with HTML_USE_SMARTYPANTS)
-	HTML_SMARTYPANTS_LATEX_DASHES             // enable LaTeX-style dashes (with HTML_USE_SMARTYPANTS)
-	HTML_SMARTYPANTS_ANGLED_QUOTES            // enable angled double quotes (with HTML_USE_SMARTYPANTS) for double quotes rendering
-	HTML_FOOTNOTE_RETURN_LINKS                // generate a link at the end of a footnote to return to the source
+	HTML_SKIP_HTML                 = 1 << iota // skip preformatted HTML blocks
+	HTML_SKIP_STYLE                            // skip embedded <style> elements
+	HTML_SKIP_IMAGES                           // skip embedded images
+	HTML_SKIP_LINKS                            // skip all links
+	HTML_SAFELINK                              // only link to trusted protocols
+	HTML_NOFOLLOW_LINKS                        // only link with rel="nofollow"
+	HTML_HREF_TARGET_BLANK                     // add a blank target
+	HTML_TOC                                   // generate a table of contents
+	HTML_OMIT_CONTENTS                         // skip the main contents (for a standalone table of contents)
+	HTML_COMPLETE_PAGE                         // generate a complete HTML page
+	HTML_USE_XHTML                             // generate XHTML output instead of HTML
+	HTML_USE_SMARTYPANTS                       // enable smart punctuation substitutions
+	HTML_SMARTYPANTS_FRACTIONS                 // enable smart fractions (with HTML_USE_SMARTYPANTS)
+	HTML_SMARTYPANTS_LATEX_DASHES              // enable LaTeX-style dashes (with HTML_USE_SMARTYPANTS)
+	HTML_SMARTYPANTS_ANGLED_QUOTES             // enable angled double quotes (with HTML_USE_SMARTYPANTS) for double quotes rendering
+	HTML_FOOTNOTE_RETURN_LINKS                 // generate a link at the end of a footnote to return to the source
 )
 
 var (


### PR DESCRIPTION
These are just minor cleanups I wanted to apply.
- Apply `gofmt` on `html.go`.
- Apply `goimports`-compatible formatting on `block.go` (space between standard and third party import groups).
- Move Travis build status image in a more pleasing, common location.
- Remove "Markdown pretty-printer output engine" from TODO steps; this is already done in [markdownfmt](https://github.com/russross/blackfriday#other-renderers).
- Remove unneeded trailing whitespace in README.
