### PR TITLE
Add programmable reference overrides

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -384,9 +384,8 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			id = data[linkB:linkE]
 		}
 
-		// find the reference with matching id (ids are case-insensitive)
-		key := string(bytes.ToLower(id))
-		lr, ok := p.refs[key]
+		// find the reference with matching id
+		lr, ok := p.getRef(string(id))
 		if !ok {
 			return 0
 
@@ -423,7 +422,6 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			}
 		}
 
-		key := string(bytes.ToLower(id))
 		if t == linkInlineFootnote {
 			// create a new reference
 			noteId = len(p.notes) + 1
@@ -453,7 +451,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			title = ref.title
 		} else {
 			// find the reference with matching id
-			lr, ok := p.refs[key]
+			lr, ok := p.getRef(string(id))
 			if !ok {
 				return 0
 			}

--- a/markdown.go
+++ b/markdown.go
@@ -222,7 +222,8 @@ func (p *parser) getRef(refid string) (ref *reference, found bool) {
 				link:     []byte(r.Link),
 				title:    []byte(r.Title),
 				noteId:   0,
-				hasBlock: false}, true
+				hasBlock: false,
+				text:     []byte(r.Text)}, true
 		}
 	}
 	// refs are case insensitive
@@ -243,6 +244,9 @@ type Reference struct {
 	Link string
 	// Title is the alternate text describing the link in more detail.
 	Title string
+	// Text is the optional text to override the ref with if the syntax used was
+	// [refid][]
+	Text string
 }
 
 // ReferenceOverrideFunc is expected to be called with a reference string and
@@ -508,6 +512,7 @@ type reference struct {
 	title    []byte
 	noteId   int // 0 if not a footnote ref
 	hasBlock bool
+	text     []byte
 }
 
 // Check whether or not data starts with a reference link.

--- a/markdown.go
+++ b/markdown.go
@@ -20,6 +20,7 @@ package blackfriday
 
 import (
 	"bytes"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -196,6 +197,7 @@ type inlineParser func(p *parser, out *bytes.Buffer, data []byte, offset int) in
 // This is constructed by the Markdown function.
 type parser struct {
 	r              Renderer
+	refOverride    ReferenceOverrideFunc
 	refs           map[string]*reference
 	inlineCallback [256]inlineParser
 	flags          int
@@ -209,11 +211,69 @@ type parser struct {
 	notes []*reference
 }
 
+func (p *parser) getRef(refid string) (ref *reference, found bool) {
+	if p.refOverride != nil {
+		r, overridden := p.refOverride(refid)
+		if overridden {
+			if r == nil {
+				return nil, false
+			}
+			return &reference{
+				link:     []byte(r.Link),
+				title:    []byte(r.Title),
+				noteId:   0,
+				hasBlock: false}, true
+		}
+	}
+	// refs are case insensitive
+	ref, found = p.refs[strings.ToLower(refid)]
+	return ref, found
+}
+
 //
 //
 // Public interface
 //
 //
+
+// Reference represents the details of a link.
+// See the documentation in Options for more details on use-case.
+type Reference struct {
+	// Link is usually the URL the reference points to.
+	Link string
+	// Title is the alternate text describing the link in more detail.
+	Title string
+}
+
+// ReferenceOverrideFunc is expected to be called with a reference string and
+// return either a valid Reference type that the reference string maps to or
+// nil. If overridden is false, the default reference logic will be executed.
+// See the documentation in Options for more details on use-case.
+type ReferenceOverrideFunc func(reference string) (ref *Reference, overridden bool)
+
+// Options represents configurable overrides and callbacks (in addition to the
+// extension flag set) for configuring a Markdown parse.
+type Options struct {
+	// Extensions is a flag set of bit-wise ORed extension bits. See the
+	// EXTENSION_* flags defined in this package.
+	Extensions int
+
+	// ReferenceOverride is an optional function callback that is called every
+	// time a reference is resolved.
+	//
+	// In Markdown, the link reference syntax can be made to resolve a link to
+	// a reference instead of an inline URL, in one of the following ways:
+	//
+	//  * [link text][refid]
+	//  * [refid][]
+	//
+	// Usually, the refid is defined at the bottom of the Markdown document. If
+	// this override function is provided, the refid is passed to the override
+	// function first, before consulting the defined refids at the bottom. If
+	// the override function indicates an override did not occur, the refids at
+	// the bottom will be used to fill in the link details.
+	ReferenceOverride ReferenceOverrideFunc
+}
 
 // MarkdownBasic is a convenience function for simple rendering.
 // It processes markdown input with no extensions enabled.
@@ -223,9 +283,7 @@ func MarkdownBasic(input []byte) []byte {
 	renderer := HtmlRenderer(htmlFlags, "", "")
 
 	// set up the parser
-	extensions := 0
-
-	return Markdown(input, renderer, extensions)
+	return MarkdownOptions(input, renderer, Options{Extensions: 0})
 }
 
 // Call Markdown with most useful extensions enabled
@@ -250,7 +308,8 @@ func MarkdownBasic(input []byte) []byte {
 func MarkdownCommon(input []byte) []byte {
 	// set up the HTML renderer
 	renderer := HtmlRenderer(commonHtmlFlags, "", "")
-	return Markdown(input, renderer, commonExtensions)
+	return MarkdownOptions(input, renderer, Options{
+		Extensions: commonExtensions})
 }
 
 // Markdown is the main rendering function.
@@ -261,15 +320,25 @@ func MarkdownCommon(input []byte) []byte {
 // To use the supplied Html or LaTeX renderers, see HtmlRenderer and
 // LatexRenderer, respectively.
 func Markdown(input []byte, renderer Renderer, extensions int) []byte {
+	return MarkdownOptions(input, renderer, Options{
+		Extensions: extensions})
+}
+
+// MarkdownOptions is just like Markdown but takes additional options through
+// the Options struct.
+func MarkdownOptions(input []byte, renderer Renderer, opts Options) []byte {
 	// no point in parsing if we can't render
 	if renderer == nil {
 		return nil
 	}
 
+	extensions := opts.Extensions
+
 	// fill in the render structure
 	p := new(parser)
 	p.r = renderer
 	p.flags = extensions
+	p.refOverride = opts.ReferenceOverride
 	p.refs = make(map[string]*reference)
 	p.maxNesting = 16
 	p.insideLink = false


### PR DESCRIPTION
If a user provides a ReferenceOverride function, then reference ids
will be passed to the given ReferenceOverride function first, before
consulting the generated reference table.

The goal here is to enable programmable support for
"WikiWords"-style identifiers or other application-specific
user-generated keywords.

Example, writing documentation:

 The [Frobnosticator][] is a very important class in our codebase.
 While it is used to frobnosticate widgets in general, it can also
 be passed to the [WeeDoodler][] to interesting effect.

This might be solveable with the HTML Renderer relative prefix, but
I didn't see a good way of making a short link to 'Frobnosticator'
relatively without having to write it twice. Maybe
'<Frobnosticator>' should work? Should Autolinks work for relative
links?

In addition, I wanted a little more richness. I plan to support
Godoc links by prefixing references with a '!', like so:

  Check out the [Frobnosticator][] helper function
  [!util.Frobnosticate()][]

The first link links to the Frobnosticator architectural overview
documentation, whereas the second links to Godoc.

Better advice on how to implement this sort of think with
Blackfriday is highly desired.