### PR TITLE
Update import path of sanitized_anchor_name.

### DIFF
--- a/block.go
+++ b/block.go
@@ -16,7 +16,7 @@ package blackfriday
 import (
 	"bytes"
 
-	"github.com/shurcooL/go/github_flavored_markdown/sanitized_anchor_name"
+	"github.com/shurcooL/sanitized_anchor_name"
 )
 
 // Parse block-level data.


### PR DESCRIPTION
- It has moved into a smaller standalone repo.
- Closes #139.

Please review. Let's see if this is an improvement and how well it works. :)

I will give push rights to that repo to the maintainers of `blackfriday`. You trust me with push rights to this repo, so I see no reason not to the same. Of course, the idea is to stick to creating issues and pull requests and merging after getting a LGTM, but just in case.