### PR TITLE
Avoid converting dates into fractions

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -839,3 +839,21 @@ func TestSmartAngledDoubleQuotes(t *testing.T) {
 
 	doTestsInlineParam(t, tests, 0, HTML_USE_SMARTYPANTS|HTML_SMARTYPANTS_ANGLED_QUOTES, HtmlRendererParameters{})
 }
+
+func TestSmartFractions(t *testing.T) {
+	var tests = []string{
+		"1/2, 1/4 and 3/4; 1/4th and 3/4ths\n",
+		"<p>&frac12;, &frac14; and &frac34;; &frac14;th and &frac34;ths</p>\n",
+		"1/2/2015, 1/4/2015, 3/4/2015; 2015/1/2, 2015/1/4, 2015/3/4.\n",
+		"<p>1/2/2015, 1/4/2015, 3/4/2015; 2015/1/2, 2015/1/4, 2015/3/4.</p>\n"}
+
+	doTestsInlineParam(t, tests, 0, HTML_USE_SMARTYPANTS, HtmlRendererParameters{})
+
+	tests = []string{
+		"1/2, 2/3, 81/100 and 1000000/1048576.\n",
+		"<p><sup>1</sup>&frasl;<sub>2</sub>, <sup>2</sup>&frasl;<sub>3</sub>, <sup>81</sup>&frasl;<sub>100</sub> and <sup>1000000</sup>&frasl;<sub>1048576</sub>.</p>\n",
+		"1/2/2015, 1/4/2015, 3/4/2015; 2015/1/2, 2015/1/4, 2015/3/4.\n",
+		"<p>1/2/2015, 1/4/2015, 3/4/2015; 2015/1/2, 2015/1/4, 2015/3/4.</p>\n"}
+
+	doTestsInlineParam(t, tests, 0, HTML_USE_SMARTYPANTS|HTML_SMARTYPANTS_FRACTIONS, HtmlRendererParameters{})
+}

--- a/smartypants.go
+++ b/smartypants.go
@@ -263,9 +263,10 @@ func smartBacktick(out *bytes.Buffer, smrt *smartypantsData, previousChar byte, 
 }
 
 func smartNumberGeneric(out *bytes.Buffer, smrt *smartypantsData, previousChar byte, text []byte) int {
-	if wordBoundary(previousChar) && len(text) >= 3 {
+	if wordBoundary(previousChar) && previousChar != '/' && len(text) >= 3 {
 		// is it of the form digits/digits(word boundary)?, i.e., \d+/\d+\b
 		// note: check for regular slash (/) or fraction slash (⁄, 0x2044, or 0xe2 81 84 in utf-8)
+		//       and avoid changing dates like 1/23/2005 into fractions.
 		numEnd := 0
 		for len(text) > numEnd && isdigit(text[numEnd]) {
 			numEnd++
@@ -289,7 +290,7 @@ func smartNumberGeneric(out *bytes.Buffer, smrt *smartypantsData, previousChar b
 			out.WriteByte(text[0])
 			return 0
 		}
-		if len(text) == denEnd || wordBoundary(text[denEnd]) {
+		if len(text) == denEnd || wordBoundary(text[denEnd]) && text[denEnd] != '/' {
 			out.WriteString("<sup>")
 			out.Write(text[:numEnd])
 			out.WriteString("</sup>&frasl;<sub>")
@@ -304,23 +305,23 @@ func smartNumberGeneric(out *bytes.Buffer, smrt *smartypantsData, previousChar b
 }
 
 func smartNumber(out *bytes.Buffer, smrt *smartypantsData, previousChar byte, text []byte) int {
-	if wordBoundary(previousChar) && len(text) >= 3 {
+	if wordBoundary(previousChar) && previousChar != '/' && len(text) >= 3 {
 		if text[0] == '1' && text[1] == '/' && text[2] == '2' {
-			if len(text) < 4 || wordBoundary(text[3]) {
+			if len(text) < 4 || wordBoundary(text[3]) && text[3] != '/' {
 				out.WriteString("&frac12;")
 				return 2
 			}
 		}
 
 		if text[0] == '1' && text[1] == '/' && text[2] == '4' {
-			if len(text) < 4 || wordBoundary(text[3]) || (len(text) >= 5 && tolower(text[3]) == 't' && tolower(text[4]) == 'h') {
+			if len(text) < 4 || wordBoundary(text[3]) && text[3] != '/' || (len(text) >= 5 && tolower(text[3]) == 't' && tolower(text[4]) == 'h') {
 				out.WriteString("&frac14;")
 				return 2
 			}
 		}
 
 		if text[0] == '3' && text[1] == '/' && text[2] == '4' {
-			if len(text) < 4 || wordBoundary(text[3]) || (len(text) >= 6 && tolower(text[3]) == 't' && tolower(text[4]) == 'h' && tolower(text[5]) == 's') {
+			if len(text) < 4 || wordBoundary(text[3]) && text[3] != '/' || (len(text) >= 6 && tolower(text[3]) == 't' && tolower(text[4]) == 'h' && tolower(text[5]) == 's') {
 				out.WriteString("&frac34;")
 				return 2
 			}


### PR DESCRIPTION
So that dates like 1/2/2005 and 2005/3/4 stay the way it is
without turning into ½/2005 and 2005/¾.

See http://discuss.gohugo.io/t/any-way-to-disable-smart-fractions/328
for discussions.