### PR TITLE
add rel="noreferrer" option

### DIFF
--- a/html.go
+++ b/html.go
@@ -31,6 +31,7 @@ const (
 	HTML_SKIP_LINKS                            // skip all links
 	HTML_SAFELINK                              // only link to trusted protocols
 	HTML_NOFOLLOW_LINKS                        // only link with rel="nofollow"
+	HTML_NOREFERRER_LINKS                      // only link with rel="noreferrer"
 	HTML_HREF_TARGET_BLANK                     // add a blank target
 	HTML_TOC                                   // generate a table of contents
 	HTML_OMIT_CONTENTS                         // skip the main contents (for a standalone table of contents)
@@ -429,9 +430,17 @@ func (options *Html) AutoLink(out *bytes.Buffer, link []byte, kind int) {
 
 	entityEscapeWithSkip(out, link, skipRanges)
 
+	var relAttrs []string
 	if options.flags&HTML_NOFOLLOW_LINKS != 0 && !isRelativeLink(link) {
-		out.WriteString("\" rel=\"nofollow")
+		relAttrs = append(relAttrs, "nofollow")
 	}
+	if options.flags&HTML_NOREFERRER_LINKS != 0 && !isRelativeLink(link) {
+		relAttrs = append(relAttrs, "noreferrer")
+	}
+	if len(relAttrs) > 0 {
+		out.WriteString(fmt.Sprintf("\" rel=\"%s", strings.Join(relAttrs, " ")))
+	}
+
 	// blank target only add to external link
 	if options.flags&HTML_HREF_TARGET_BLANK != 0 && !isRelativeLink(link) {
 		out.WriteString("\" target=\"_blank")
@@ -535,9 +544,17 @@ func (options *Html) Link(out *bytes.Buffer, link []byte, title []byte, content 
 		out.WriteString("\" title=\"")
 		attrEscape(out, title)
 	}
+	var relAttrs []string
 	if options.flags&HTML_NOFOLLOW_LINKS != 0 && !isRelativeLink(link) {
-		out.WriteString("\" rel=\"nofollow")
+		relAttrs = append(relAttrs, "nofollow")
 	}
+	if options.flags&HTML_NOREFERRER_LINKS != 0 && !isRelativeLink(link) {
+		relAttrs = append(relAttrs, "noreferrer")
+	}
+	if len(relAttrs) > 0 {
+		out.WriteString(fmt.Sprintf("\" rel=\"%s", strings.Join(relAttrs, " ")))
+	}
+
 	// blank target only add to external link
 	if options.flags&HTML_HREF_TARGET_BLANK != 0 && !isRelativeLink(link) {
 		out.WriteString("\" target=\"_blank")

--- a/inline_test.go
+++ b/inline_test.go
@@ -445,15 +445,35 @@ func TestInlineLink(t *testing.T) {
 
 }
 
-func TestNofollowLink(t *testing.T) {
-	var tests = []string{
+func TestRelAttrLink(t *testing.T) {
+	var nofollowTests = []string{
 		"[foo](http://bar.com/foo/)\n",
 		"<p><a href=\"http://bar.com/foo/\" rel=\"nofollow\">foo</a></p>\n",
 
 		"[foo](/bar/)\n",
 		"<p><a href=\"/bar/\">foo</a></p>\n",
 	}
-	doTestsInlineParam(t, tests, 0, HTML_SAFELINK|HTML_NOFOLLOW_LINKS,
+	doTestsInlineParam(t, nofollowTests, 0, HTML_SAFELINK|HTML_NOFOLLOW_LINKS,
+		HtmlRendererParameters{})
+
+	var noreferrerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"noreferrer\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, noreferrerTests, 0, HTML_SAFELINK|HTML_NOREFERRER_LINKS,
+		HtmlRendererParameters{})
+
+	var nofollownoreferrerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"nofollow noreferrer\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, nofollownoreferrerTests, 0, HTML_SAFELINK|HTML_NOFOLLOW_LINKS|HTML_NOREFERRER_LINKS,
 		HtmlRendererParameters{})
 }
 


### PR DESCRIPTION
This adds a flag to add a `rel="noreferrer"` attribute to generated links. This is generally a good idea when rendering third-party HTML with the `HTML_HREF_TARGET_BLANK` flag. Otherwise the linked-to page can use `window.opener.location.replace('http://attacker.com')` to replace the URL of the original tab, which is a potential security vulnerability.

Tests have been added for this case. Thanks for making this awesome library!