### PR TITLE
Fix recognition of consecutive footnotes

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -348,7 +348,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 		i++
 
 	// reference style link
-	case i < len(data) && data[i] == '[':
+	case i < len(data)-1 && data[i] == '[' && data[i+1] != '^':
 		var id []byte
 
 		// look for the id

--- a/inline_test.go
+++ b/inline_test.go
@@ -805,6 +805,12 @@ what happens here
 
 	"empty footnote[^]\n\n[^]: fn text",
 	"<p>empty footnote<sup class=\"footnote-ref\" id=\"fnref:\"><a rel=\"footnote\" href=\"#fn:\">1</a></sup></p>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:\">fn text\n</li>\n</ol>\n</div>\n",
+
+	"Some text.[^note1]\n\n[^note1]: fn1",
+	"<p>Some text.<sup class=\"footnote-ref\" id=\"fnref:note1\"><a rel=\"footnote\" href=\"#fn:note1\">1</a></sup></p>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:note1\">fn1\n</li>\n</ol>\n</div>\n",
+
+	"Some text.[^note1][^note2]\n\n[^note1]: fn1\n[^note2]: fn2\n",
+	"<p>Some text.<sup class=\"footnote-ref\" id=\"fnref:note1\"><a rel=\"footnote\" href=\"#fn:note1\">1</a></sup><sup class=\"footnote-ref\" id=\"fnref:note2\"><a rel=\"footnote\" href=\"#fn:note2\">2</a></sup></p>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:note1\">fn1\n</li>\n<li id=\"fn:note2\">fn2\n</li>\n</ol>\n</div>\n",
 }
 
 func TestFootnotes(t *testing.T) {


### PR DESCRIPTION
The second footnote was treated as if the pair of them were a reference
style link, without checking if the second bit is another footnote.

Fixes issue #158.