### PR TITLE
Implement backslash hard line break extension

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -167,9 +167,10 @@ func lineBreak(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	out.Truncate(eol)
 
 	precededByTwoSpaces := offset >= 2 && data[offset-2] == ' ' && data[offset-1] == ' '
+	precededByBackslash := offset >= 1 && data[offset-1] == '\\' // see http://spec.commonmark.org/0.18/#example-527
 
 	// should there be a hard line break here?
-	if p.flags&EXTENSION_HARD_LINE_BREAK == 0 && !precededByTwoSpaces {
+	if p.flags&EXTENSION_HARD_LINE_BREAK == 0 && !precededByTwoSpaces && !precededByBackslash {
 		return 0
 	}
 

--- a/inline.go
+++ b/inline.go
@@ -168,6 +168,7 @@ func lineBreak(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 
 	precededByTwoSpaces := offset >= 2 && data[offset-2] == ' ' && data[offset-1] == ' '
 	precededByBackslash := offset >= 1 && data[offset-1] == '\\' // see http://spec.commonmark.org/0.18/#example-527
+	precededByBackslash = precededByBackslash && p.flags&EXTENSION_BACKSLASH_LINE_BREAK != 0
 
 	// should there be a hard line break here?
 	if p.flags&EXTENSION_HARD_LINE_BREAK == 0 && !precededByTwoSpaces && !precededByBackslash {

--- a/inline.go
+++ b/inline.go
@@ -174,6 +174,9 @@ func lineBreak(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 		return 0
 	}
 
+	if precededByBackslash && eol > 0 {
+		out.Truncate(eol - 1)
+	}
 	p.r.LineBreak(out)
 	return 1
 }

--- a/inline_test.go
+++ b/inline_test.go
@@ -332,10 +332,34 @@ func TestLineBreak(t *testing.T) {
 		"this line \ndoes not\n",
 		"<p>this line\ndoes not</p>\n",
 
+		"this line\\\ndoes not\n",
+		"<p>this line\\\ndoes not</p>\n",
+
+		"this line\\ \ndoes not\n",
+		"<p>this line\\\ndoes not</p>\n",
+
 		"this has an   \nextra space\n",
 		"<p>this has an<br />\nextra space</p>\n",
 	}
 	doTestsInline(t, tests)
+
+	tests = []string{
+		"this line  \nhas a break\n",
+		"<p>this line<br />\nhas a break</p>\n",
+
+		"this line \ndoes not\n",
+		"<p>this line\ndoes not</p>\n",
+
+		"this line\\\nhas a break\n",
+		"<p>this line<br />\nhas a break</p>\n",
+
+		"this line\\ \ndoes not\n",
+		"<p>this line\\\ndoes not</p>\n",
+
+		"this has an   \nextra space\n",
+		"<p>this has an<br />\nextra space</p>\n",
+	}
+	doTestsInlineParam(t, tests, EXTENSION_BACKSLASH_LINE_BREAK, 0, HtmlRendererParameters{})
 }
 
 func TestInlineLink(t *testing.T) {

--- a/markdown.go
+++ b/markdown.go
@@ -42,6 +42,7 @@ const (
 	EXTENSION_HEADER_IDS                             // specify header IDs  with {#id}
 	EXTENSION_TITLEBLOCK                             // Titleblock ala pandoc
 	EXTENSION_AUTO_HEADER_IDS                        // Create the header ID from the text
+	EXTENSION_BACKSLASH_LINE_BREAK                   // translate trailing backslashes into line breaks
 
 	commonHtmlFlags = 0 |
 		HTML_USE_XHTML |
@@ -56,7 +57,8 @@ const (
 		EXTENSION_AUTOLINK |
 		EXTENSION_STRIKETHROUGH |
 		EXTENSION_SPACE_HEADERS |
-		EXTENSION_HEADER_IDS
+		EXTENSION_HEADER_IDS |
+		EXTENSION_BACKSLASH_LINE_BREAK
 )
 
 // These are the possible flag values for the link renderer.


### PR DESCRIPTION
Many don't like double space because it's not visible. For this, CommonMark and other dialects allow backslash hard line breaks. See http://spec.commonmark.org/0.18/#example-527

I added an extension (EXTENSION_BACKSLASH_LINE_BREAK), added by default in Common profile.

All tests pass.
