### PR TITLE
Do not emit newline after <img> tag.

### DIFF
--- a/html.go
+++ b/html.go
@@ -76,7 +76,7 @@ type HtmlRendererParameters struct {
 // Do not create this directly, instead use the HtmlRenderer function.
 type Html struct {
 	flags    int    // HTML_* options
-	closeTag string // how to end singleton tags: either " />\n" or ">\n"
+	closeTag string // how to end singleton tags: either " />" or ">"
 	title    string // document title
 	css      string // optional css file url (used with HTML_COMPLETE_PAGE)
 
@@ -95,8 +95,8 @@ type Html struct {
 }
 
 const (
-	xhtmlClose = " />\n"
-	htmlClose  = ">\n"
+	xhtmlClose = " />"
+	htmlClose  = ">"
 )
 
 // HtmlRenderer creates and configures an Html object, which
@@ -250,6 +250,7 @@ func (options *Html) HRule(out *bytes.Buffer) {
 	doubleSpace(out)
 	out.WriteString("<hr")
 	out.WriteString(options.closeTag)
+	out.WriteByte('\n')
 }
 
 func (options *Html) BlockCode(out *bytes.Buffer, text []byte, lang string) {
@@ -512,12 +513,12 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 
 	out.WriteByte('"')
 	out.WriteString(options.closeTag)
-	return
 }
 
 func (options *Html) LineBreak(out *bytes.Buffer) {
 	out.WriteString("<br")
 	out.WriteString(options.closeTag)
+	out.WriteByte('\n')
 }
 
 func (options *Html) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {

--- a/inline_test.go
+++ b/inline_test.go
@@ -441,22 +441,22 @@ func TestInlineLink(t *testing.T) {
 		"<p>[foo]()</p>\n",
 
 		"![foo](/bar/)\n",
-		"<p><img src=\"/bar/\" alt=\"foo\" />\n</p>\n",
+		"<p><img src=\"/bar/\" alt=\"foo\" /></p>\n",
 
 		"![foo with a title](/bar/ \"title\")\n",
-		"<p><img src=\"/bar/\" alt=\"foo with a title\" title=\"title\" />\n</p>\n",
+		"<p><img src=\"/bar/\" alt=\"foo with a title\" title=\"title\" /></p>\n",
 
 		"![foo with a title](/bar/\t\"title\")\n",
-		"<p><img src=\"/bar/\" alt=\"foo with a title\" title=\"title\" />\n</p>\n",
+		"<p><img src=\"/bar/\" alt=\"foo with a title\" title=\"title\" /></p>\n",
 
 		"![foo with a title](/bar/ \"title\"  )\n",
-		"<p><img src=\"/bar/\" alt=\"foo with a title\" title=\"title\" />\n</p>\n",
+		"<p><img src=\"/bar/\" alt=\"foo with a title\" title=\"title\" /></p>\n",
 
 		"![foo with a title](/bar/ title with no quotes)\n",
-		"<p><img src=\"/bar/ title with no quotes\" alt=\"foo with a title\" />\n</p>\n",
+		"<p><img src=\"/bar/ title with no quotes\" alt=\"foo with a title\" /></p>\n",
 
 		"![](img.jpg)\n",
-		"<p><img src=\"img.jpg\" alt=\"\" />\n</p>\n",
+		"<p><img src=\"img.jpg\" alt=\"\" /></p>\n",
 
 		"[link](url)\n",
 		"<p><a href=\"url\">link</a></p>\n",
@@ -501,7 +501,7 @@ func TestInlineLink(t *testing.T) {
 		"<p><a href=\"with whitespace\">link</a></p>\n",
 
 		"[![image](someimage)](with image)\n",
-		"<p><a href=\"with image\"><img src=\"someimage\" alt=\"image\" />\n</a></p>\n",
+		"<p><a href=\"with image\"><img src=\"someimage\" alt=\"image\" /></a></p>\n",
 
 		"[link](url \"one quote)\n",
 		"<p><a href=\"url &quot;one quote\">link</a></p>\n",


### PR DESCRIPTION
- This changes HTML renderer not to always add a newline character after \<img\> tags. This is desirable because \<img\> tags can be inlined, and sometimes you want to avoid whitespace on left and right sides. Previous behavior of always adding a newline would unavoidably create whitespace after \<img\> tag.
- Update all tests to match new behavior. There are few changes, and they're completely isolated to inline image tests.

Fixes #169.

Change Overview
-------

Consider the following Markdown input:

```Markdown
Title
===

An inline image ![img](http://www.example.com/image.png) looks like that.

![standalone image](http://www.example.com/image.png)

Another paragraph.
```

Previously, this would generate the following HTML output:

```HTML
<h1>Title</h1>

<p>An inline image <img src="http://www.example.com/image.png" alt="img" />
 looks like that.</p>

<p><img src="http://www.example.com/image.png" alt="standalone image" />
</p>

<p>Another paragraph.</p>
```

After this PR, it will generate this instead:

```HTML
<h1>Title</h1>

<p>An inline image <img src="http://www.example.com/image.png" alt="img" /> looks like that.</p>

<p><img src="http://www.example.com/image.png" alt="standalone image" /></p>

<p>Another paragraph.</p>
```

That looks like an improvement in rendering to me, and I think this change should be done.