### PR TITLE
Add definition lists extension support

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -801,6 +801,86 @@ func TestOrderedList(t *testing.T) {
 	doTestsBlock(t, tests, 0)
 }
 
+func TestDefinitionList(t *testing.T) {
+	var tests = []string{
+		"Term 1\n:   Definition a\n",
+		"<dl>\n<dt>Term 1</dt>\n<dd>Definition a</dd>\n</dl>\n",
+
+		"Term 1\n:   Definition a \n",
+		"<dl>\n<dt>Term 1</dt>\n<dd>Definition a</dd>\n</dl>\n",
+
+		"Term 1\n:   Definition a\n:   Definition b\n",
+		"<dl>\n<dt>Term 1</dt>\n<dd>Definition a</dd>\n<dd>Definition b</dd>\n</dl>\n",
+
+		"Term 1\n:   Definition a\n\nTerm 2\n:   Definition b\n",
+		"<dl>\n" +
+			"<dt>Term 1</dt>\n" +
+			"<dd>Definition a</dd>\n" +
+			"<dt>Term 2</dt>\n" +
+			"<dd>Definition b</dd>\n" +
+			"</dl>\n",
+
+		"Term 1\n:   Definition a\n:   Definition b\n\nTerm 2\n:   Definition c\n",
+		"<dl>\n" +
+			"<dt>Term 1</dt>\n" +
+			"<dd>Definition a</dd>\n" +
+			"<dd>Definition b</dd>\n" +
+			"<dt>Term 2</dt>\n" +
+			"<dd>Definition c</dd>\n" +
+			"</dl>\n",
+
+		"Term 1\n\n:   Definition a\n\nTerm 2\n\n:   Definition b\n",
+		"<dl>\n" +
+			"<dt>Term 1</dt>\n" +
+			"<dd><p>Definition a</p></dd>\n" +
+			"<dt>Term 2</dt>\n" +
+			"<dd><p>Definition b</p></dd>\n" +
+			"</dl>\n",
+
+		"Term 1\n\n:   Definition a\n\n:   Definition b\n\nTerm 2\n\n:   Definition c\n",
+		"<dl>\n" +
+			"<dt>Term 1</dt>\n" +
+			"<dd><p>Definition a</p></dd>\n" +
+			"<dd><p>Definition b</p></dd>\n" +
+			"<dt>Term 2</dt>\n" +
+			"<dd><p>Definition c</p></dd>\n" +
+			"</dl>\n",
+
+		"Term 1\n:   Definition a\nNext line\n",
+		"<dl>\n<dt>Term 1</dt>\n<dd>Definition a\nNext line</dd>\n</dl>\n",
+
+		"Term 1\n:   Definition a\n  Next line\n",
+		"<dl>\n<dt>Term 1</dt>\n<dd>Definition a\nNext line</dd>\n</dl>\n",
+
+		"Term 1\n:   Definition a \n  Next line \n",
+		"<dl>\n<dt>Term 1</dt>\n<dd>Definition a\nNext line</dd>\n</dl>\n",
+
+		"Term 1\n:   Definition a\nNext line\n\nTerm 2\n:   Definition b",
+		"<dl>\n" +
+			"<dt>Term 1</dt>\n" +
+			"<dd>Definition a\nNext line</dd>\n" +
+			"<dt>Term 2</dt>\n" +
+			"<dd>Definition b</dd>\n" +
+			"</dl>\n",
+
+		"Term 1\n: Definition a\n",
+		"<dl>\n<dt>Term 1</dt>\n<dd>Definition a</dd>\n</dl>\n",
+
+		"Term 1\n:Definition a\n",
+		"<p>Term 1\n:Definition a</p>\n",
+
+		"Term 1\n\n:   Definition a\n\nTerm 2\n\n:   Definition b\n\nText 1",
+		"<dl>\n" +
+			"<dt>Term 1</dt>\n" +
+			"<dd><p>Definition a</p></dd>\n" +
+			"<dt>Term 2</dt>\n" +
+			"<dd><p>Definition b</p></dd>\n" +
+			"</dl>\n" +
+			"\n<p>Text 1</p>\n",
+	}
+	doTestsBlock(t, tests, EXTENSION_DEFINITION_LISTS)
+}
+
 func TestPreformattedHtml(t *testing.T) {
 	var tests = []string{
 		"<div></div>\n",

--- a/html.go
+++ b/html.go
@@ -375,7 +375,9 @@ func (options *Html) List(out *bytes.Buffer, text func() bool, flags int) {
 	marker := out.Len()
 	doubleSpace(out)
 
-	if flags&LIST_TYPE_ORDERED != 0 {
+	if flags&LIST_TYPE_DEFINITION != 0 {
+		out.WriteString("<dl>")
+	} else if flags&LIST_TYPE_ORDERED != 0 {
 		out.WriteString("<ol>")
 	} else {
 		out.WriteString("<ul>")
@@ -384,7 +386,9 @@ func (options *Html) List(out *bytes.Buffer, text func() bool, flags int) {
 		out.Truncate(marker)
 		return
 	}
-	if flags&LIST_TYPE_ORDERED != 0 {
+	if flags&LIST_TYPE_DEFINITION != 0 {
+		out.WriteString("</dl>\n")
+	} else if flags&LIST_TYPE_ORDERED != 0 {
 		out.WriteString("</ol>\n")
 	} else {
 		out.WriteString("</ul>\n")
@@ -392,12 +396,25 @@ func (options *Html) List(out *bytes.Buffer, text func() bool, flags int) {
 }
 
 func (options *Html) ListItem(out *bytes.Buffer, text []byte, flags int) {
-	if flags&LIST_ITEM_CONTAINS_BLOCK != 0 || flags&LIST_ITEM_BEGINNING_OF_LIST != 0 {
+	if (flags&LIST_ITEM_CONTAINS_BLOCK != 0 && flags&LIST_TYPE_DEFINITION == 0) ||
+		flags&LIST_ITEM_BEGINNING_OF_LIST != 0 {
 		doubleSpace(out)
 	}
-	out.WriteString("<li>")
+	if flags&LIST_TYPE_TERM != 0 {
+		out.WriteString("<dt>")
+	} else if flags&LIST_TYPE_DEFINITION != 0 {
+		out.WriteString("<dd>")
+	} else {
+		out.WriteString("<li>")
+	}
 	out.Write(text)
-	out.WriteString("</li>\n")
+	if flags&LIST_TYPE_TERM != 0 {
+		out.WriteString("</dt>\n")
+	} else if flags&LIST_TYPE_DEFINITION != 0 {
+		out.WriteString("</dd>\n")
+	} else {
+		out.WriteString("</li>\n")
+	}
 }
 
 func (options *Html) Paragraph(out *bytes.Buffer, text func() bool) {

--- a/markdown.go
+++ b/markdown.go
@@ -44,6 +44,7 @@ const (
 	EXTENSION_TITLEBLOCK                             // Titleblock ala pandoc
 	EXTENSION_AUTO_HEADER_IDS                        // Create the header ID from the text
 	EXTENSION_BACKSLASH_LINE_BREAK                   // translate trailing backslashes into line breaks
+	EXTENSION_DEFINITION_LISTS                       // render definition lists
 
 	commonHtmlFlags = 0 |
 		HTML_USE_XHTML |
@@ -59,7 +60,8 @@ const (
 		EXTENSION_STRIKETHROUGH |
 		EXTENSION_SPACE_HEADERS |
 		EXTENSION_HEADER_IDS |
-		EXTENSION_BACKSLASH_LINE_BREAK
+		EXTENSION_BACKSLASH_LINE_BREAK |
+		EXTENSION_DEFINITION_LISTS
 )
 
 // These are the possible flag values for the link renderer.
@@ -76,6 +78,8 @@ const (
 // These are mostly of interest if you are writing a new output format.
 const (
 	LIST_TYPE_ORDERED = 1 << iota
+	LIST_TYPE_DEFINITION
+	LIST_TYPE_TERM
 	LIST_ITEM_CONTAINS_BLOCK
 	LIST_ITEM_BEGINNING_OF_LIST
 	LIST_ITEM_END_OF_LIST


### PR DESCRIPTION
Hi,

This PR implements definition lists support as described [here](https://michelf.ca/projects/php-markdown/extra/#def-list).

This support is available as an extension using `EXTENSION_DEFINITION_LISTS`.

Hoping it will suits you.

King regards,

Vincent