### PR TITLE
Handle comments within a block

### DIFF
--- a/block.go
+++ b/block.go
@@ -399,23 +399,7 @@ func (p *parser) html(out *bytes.Buffer, data []byte, doRender bool) int {
 
 // HTML comment, lax form
 func (p *parser) htmlComment(out *bytes.Buffer, data []byte, doRender bool) int {
-	if data[0] != '<' || data[1] != '!' || data[2] != '-' || data[3] != '-' {
-		return 0
-	}
-
-	i := 5
-
-	// scan for an end-of-comment marker, across lines if necessary
-	for i < len(data) && !(data[i-2] == '-' && data[i-1] == '-' && data[i] == '>') {
-		i++
-	}
-	i++
-
-	// no end-of-comment marker
-	if i >= len(data) {
-		return 0
-	}
-
+	i := p.inlineHtmlComment(out, data)
 	// needs to end with a blank line
 	if j := p.isEmpty(data[i:]); j > 0 {
 		size := i + j
@@ -429,7 +413,6 @@ func (p *parser) htmlComment(out *bytes.Buffer, data []byte, doRender bool) int 
 		}
 		return size
 	}
-
 	return 0
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -1401,7 +1401,17 @@ func TestTitleBlock_EXTENSION_TITLEBLOCK(t *testing.T) {
 			"Yep, more here too\n" +
 			"</h1>",
 	}
-
 	doTestsBlock(t, tests, EXTENSION_TITLEBLOCK)
+}
 
+func TestBlockComments(t *testing.T) {
+	var tests = []string{
+		"Some text\n\n<!-- comment -->\n",
+		"<p>Some text</p>\n\n<!-- comment -->\n",
+		"Some text\n\n<!--\n\nmultiline\ncomment\n-->\n",
+		"<p>Some text</p>\n\n<!--\n\nmultiline\ncomment\n-->\n",
+		"Some text\n\n<!--\n\n<div><p>Commented</p>\n<span>html</span></div>\n-->\n",
+		"<p>Some text</p>\n\n<!--\n\n<div><p>Commented</p>\n<span>html</span></div>\n-->\n",
+	}
+	doTestsBlock(t, tests, 0)
 }

--- a/block_test.go
+++ b/block_test.go
@@ -1408,8 +1408,10 @@ func TestBlockComments(t *testing.T) {
 	var tests = []string{
 		"Some text\n\n<!-- comment -->\n",
 		"<p>Some text</p>\n\n<!-- comment -->\n",
+
 		"Some text\n\n<!--\n\nmultiline\ncomment\n-->\n",
 		"<p>Some text</p>\n\n<!--\n\nmultiline\ncomment\n-->\n",
+
 		"Some text\n\n<!--\n\n<div><p>Commented</p>\n<span>html</span></div>\n-->\n",
 		"<p>Some text</p>\n\n<!--\n\n<div><p>Commented</p>\n<span>html</span></div>\n-->\n",
 	}

--- a/inline.go
+++ b/inline.go
@@ -547,12 +547,33 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	return i
 }
 
+func (p *parser) inlineHtmlComment(out *bytes.Buffer, data []byte) int {
+	if len(data) < 5 {
+		return 0
+	}
+	if data[0] != '<' || data[1] != '!' || data[2] != '-' || data[3] != '-' {
+		return 0
+	}
+	i := 5
+	// scan for an end-of-comment marker, across lines if necessary
+	for i < len(data) && !(data[i-2] == '-' && data[i-1] == '-' && data[i] == '>') {
+		i++
+	}
+	// no end-of-comment marker
+	if i >= len(data) {
+		return 0
+	}
+	return i + 1
+}
+
 // '<' when tags or autolinks are allowed
 func leftAngle(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	data = data[offset:]
 	altype := LINK_TYPE_NOT_AUTOLINK
 	end := tagLength(data, &altype)
-
+	if size := p.inlineHtmlComment(out, data); size > 0 {
+		end = size
+	}
 	if end > 2 {
 		if altype != LINK_TYPE_NOT_AUTOLINK {
 			var uLink bytes.Buffer

--- a/inline_test.go
+++ b/inline_test.go
@@ -973,6 +973,28 @@ func TestFootnotesWithParameters(t *testing.T) {
 	doTestsInlineParam(t, tests, Options{Extensions: EXTENSION_FOOTNOTES}, HTML_FOOTNOTE_RETURN_LINKS, params)
 }
 
+func TestInlineComments(t *testing.T) {
+	var tests = []string{
+		"Hello <!-- there ->\n",
+		"<p>Hello &lt;!&mdash; there &ndash;&gt;</p>\n",
+		"Hello <!-- there -->\n",
+		"<p>Hello <!-- there --></p>\n",
+		"Hello <!-- there -->",
+		"<p>Hello <!-- there --></p>\n",
+		"Hello <!---->\n",
+		"<p>Hello <!----></p>\n",
+		"Hello <!-- there -->\na",
+		"<p>Hello <!-- there -->\na</p>\n",
+		"* list <!-- item -->\n",
+		"<ul>\n<li>list <!-- item --></li>\n</ul>\n",
+		"<!-- Front --> comment\n",
+		"<p><!-- Front --> comment</p>\n",
+		"blahblah\n<!--- foo -->\nrhubarb\n",
+		"<p>blahblah\n<!--- foo -->\nrhubarb</p>\n",
+	}
+	doTestsInlineParam(t, tests, Options{}, HTML_USE_SMARTYPANTS, HtmlRendererParameters{})
+}
+
 func TestSmartDoubleQuotes(t *testing.T) {
 	var tests = []string{
 		"this should be normal \"quoted\" text.\n",

--- a/inline_test.go
+++ b/inline_test.go
@@ -977,18 +977,25 @@ func TestInlineComments(t *testing.T) {
 	var tests = []string{
 		"Hello <!-- there ->\n",
 		"<p>Hello &lt;!&mdash; there &ndash;&gt;</p>\n",
+
 		"Hello <!-- there -->\n",
 		"<p>Hello <!-- there --></p>\n",
+
 		"Hello <!-- there -->",
 		"<p>Hello <!-- there --></p>\n",
+
 		"Hello <!---->\n",
 		"<p>Hello <!----></p>\n",
+
 		"Hello <!-- there -->\na",
 		"<p>Hello <!-- there -->\na</p>\n",
+
 		"* list <!-- item -->\n",
 		"<ul>\n<li>list <!-- item --></li>\n</ul>\n",
+
 		"<!-- Front --> comment\n",
 		"<p><!-- Front --> comment</p>\n",
+
 		"blahblah\n<!--- foo -->\nrhubarb\n",
 		"<p>blahblah\n<!--- foo -->\nrhubarb</p>\n",
 	}


### PR DESCRIPTION
Added test cases both for inline and block workflows.

Closes #136.