### PR TITLE
Fix bug parsing emphasis

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -910,7 +910,7 @@ func isMailtoAutoLink(data []byte) int {
 
 // look for the next emph char, skipping other constructs
 func helperFindEmphChar(data []byte, c byte) int {
-	i := 1
+	i := 0
 
 	for i < len(data) {
 		for i < len(data) && data[i] != c && data[i] != '`' && data[i] != '[' {

--- a/inline_test.go
+++ b/inline_test.go
@@ -263,6 +263,12 @@ func TestStrong(t *testing.T) {
 
 		"mix of **markers__\n",
 		"<p>mix of **markers__</p>\n",
+
+		"**`/usr`** : this folder is named `usr`\n",
+		"<p><strong><code>/usr</code></strong> : this folder is named <code>usr</code></p>\n",
+
+		"**`/usr`** :\n\n this folder is named `usr`\n",
+		"<p><strong><code>/usr</code></strong> :</p>\n\n<p>this folder is named <code>usr</code></p>\n",
 	}
 	doTestsInline(t, tests)
 }
@@ -291,7 +297,7 @@ func TestEmphasisMix(t *testing.T) {
 		"<p><strong>improper *nesting</strong> is* bad</p>\n",
 
 		"*improper **nesting* is** bad\n",
-		"<p><em>improper **nesting</em> is** bad</p>\n",
+		"<p>*improper <strong>nesting* is</strong> bad</p>\n",
 	}
 	doTestsInline(t, tests)
 }


### PR DESCRIPTION
Start searching for emphasis character at 0th index instead of 1st.
Fixes a corner case with doubly emphasised code span followed by
another code span on the same line.

Changes interpretation of improperly nested emphasis, hence the change
in TestEmphasisMix().

Closes #156.