### PR TITLE
Fix footnote followed by a reference style link

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -191,6 +191,13 @@ const (
 	linkInlineFootnote
 )
 
+func isReferenceStyleLink(data []byte, pos int, t linkType) bool {
+	if t == linkDeferredFootnote {
+		return false
+	}
+	return pos < len(data)-1 && data[pos] == '[' && data[pos+1] != '^'
+}
+
 // '[': parse a link or an image or a footnote
 func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	// no links allowed inside regular links, footnote, and deferred footnotes
@@ -353,7 +360,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 		i++
 
 	// reference style link
-	case i < len(data)-1 && data[i] == '[' && data[i+1] != '^':
+	case isReferenceStyleLink(data, i, t):
 		var id []byte
 		altContentConsidered := false
 
@@ -395,7 +402,6 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 		lr, ok := p.getRef(string(id))
 		if !ok {
 			return 0
-
 		}
 
 		// keep link and title from reference

--- a/inline_test.go
+++ b/inline_test.go
@@ -942,6 +942,24 @@ what happens here
 
 	"Some text.[^note1][^note2]\n\n[^note1]: fn1\n[^note2]: fn2\n",
 	"<p>Some text.<sup class=\"footnote-ref\" id=\"fnref:note1\"><a rel=\"footnote\" href=\"#fn:note1\">1</a></sup><sup class=\"footnote-ref\" id=\"fnref:note2\"><a rel=\"footnote\" href=\"#fn:note2\">2</a></sup></p>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:note1\">fn1\n</li>\n<li id=\"fn:note2\">fn2\n</li>\n</ol>\n</div>\n",
+
+	`Bla bla [^1] [WWW][w3]
+
+[^1]: This is a footnote
+
+[w3]: http://www.w3.org/
+`,
+	`<p>Bla bla <sup class="footnote-ref" id="fnref:1"><a rel="footnote" href="#fn:1">1</a></sup> <a href="http://www.w3.org/">WWW</a></p>
+<div class="footnotes">
+
+<hr />
+
+<ol>
+<li id="fn:1">This is a footnote
+</li>
+</ol>
+</div>
+`,
 }
 
 func TestFootnotes(t *testing.T) {


### PR DESCRIPTION
When parsing a deferred footnote, we already know it's a footnote from
the '[^' part, so we can use that to hit a proper switch branch
(default) a bit later on.

Closes #164.