### PR TITLE
Fix escaping asterisks within emphasis

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -919,14 +919,13 @@ func helperFindEmphChar(data []byte, c byte) int {
 		if i >= len(data) {
 			return 0
 		}
-		if data[i] == c {
-			return i
-		}
-
 		// do not count escaped chars
 		if i != 0 && data[i-1] == '\\' {
 			i++
 			continue
+		}
+		if data[i] == c {
+			return i
 		}
 
 		if data[i] == '`' {

--- a/inline_test.go
+++ b/inline_test.go
@@ -153,6 +153,9 @@ func TestEmphasis(t *testing.T) {
 
 		"mix of *markers_\n",
 		"<p>mix of *markers_</p>\n",
+
+		"*What is A\\* algorithm?*\n",
+		"<p><em>What is A* algorithm?</em></p>\n",
 	}
 	doTestsInline(t, tests)
 }


### PR DESCRIPTION
First check for escaped character, *then* look if i-th character is an
emphasis character.

Closes #18.