### PR TITLE
support for embeding css into the generated-html

### DIFF
--- a/html.go
+++ b/html.go
@@ -18,6 +18,8 @@ package blackfriday
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -42,6 +44,7 @@ const (
 	HTML_SMARTYPANTS_LATEX_DASHES              // enable LaTeX-style dashes (with HTML_USE_SMARTYPANTS)
 	HTML_SMARTYPANTS_ANGLED_QUOTES             // enable angled double quotes (with HTML_USE_SMARTYPANTS) for double quotes rendering
 	HTML_FOOTNOTE_RETURN_LINKS                 // generate a link at the end of a footnote to return to the source
+	HTML_EMBED_CSS                             // if css is given, embed the content of the file into the HTML
 )
 
 var (
@@ -696,11 +699,21 @@ func (options *Html) DocumentHeader(out *bytes.Buffer) {
 	out.WriteString(ending)
 	out.WriteString(">\n")
 	if options.css != "" {
-		out.WriteString("  <link rel=\"stylesheet\" type=\"text/css\" href=\"")
-		attrEscape(out, []byte(options.css))
-		out.WriteString("\"")
-		out.WriteString(ending)
-		out.WriteString(">\n")
+		if options.flags&HTML_EMBED_CSS != 1 {
+			out.WriteString("  <style>")
+			css, err := ioutil.ReadFile(options.css)
+			if err != nil {
+				log.Fatalf("couldn't read css '%s': %v", options.css, err)
+			}
+			out.Write(css)
+			out.WriteString("  </style>\n")
+		} else {
+			out.WriteString("  <link rel=\"stylesheet\" type=\"text/css\" href=\"")
+			attrEscape(out, []byte(options.css))
+			out.WriteString("\"")
+			out.WriteString(ending)
+			out.WriteString(">\n")
+		}
 	}
 	out.WriteString("</head>\n")
 	out.WriteString("<body>\n")


### PR DESCRIPTION
Hi,

thanks a ton for blackfriday!  I had the need to embed a css-file into the generated HTML-output (so I have a fully self-contained, single file to use as attachment, f.e.), so I added an option to the flags to communicate that to the renderer and read the css-file and write it inside <style>-tags.

I hope you find that useful.  There will be a corresponding pull-request for the blackfriday-tool.

Cheers,
  Özgür