### PR TITLE
Fix issue 122: fenced code blocks inside blockquotes

### DIFF
--- a/block.go
+++ b/block.go
@@ -909,7 +909,17 @@ func (p *parser) quote(out *bytes.Buffer, data []byte) int {
 	beg, end := 0, 0
 	for beg < len(data) {
 		end = beg
+		// Step over whole lines, collecting them. While doing that, check for
+		// fenced code and if one's found, incorporate it altogether,
+		// irregardless of any contents inside it
 		for data[end] != '\n' {
+			if p.flags&EXTENSION_FENCED_CODE != 0 {
+				if i := p.fencedCode(out, data[end:], false); i > 0 {
+					// -1 to compensate for the extra end++ after the loop:
+					end += i - 1
+					break
+				}
+			}
 			end++
 		}
 		end++

--- a/block.go
+++ b/block.go
@@ -893,7 +893,7 @@ func (p *parser) quotePrefix(data []byte) int {
 
 // blockquote ends with at least one blank line
 // followed by something without a blockquote prefix
-func terminateBlockquote(p *parser, data []byte, beg, end int) bool {
+func (p *parser) terminateBlockquote(data []byte, beg, end int) bool {
 	if p.isEmpty(data[beg:]) <= 0 {
 		return false
 	}
@@ -927,7 +927,7 @@ func (p *parser) quote(out *bytes.Buffer, data []byte) int {
 		if pre := p.quotePrefix(data[beg:]); pre > 0 {
 			// skip the prefix
 			beg += pre
-		} else if terminateBlockquote(p, data, beg, end) {
+		} else if p.terminateBlockquote(data, beg, end) {
 			break
 		}
 

--- a/block.go
+++ b/block.go
@@ -1342,6 +1342,14 @@ func (p *parser) paragraph(out *bytes.Buffer, data []byte) int {
 			return i
 		}
 
+		// if there's a fenced code block, paragraph is over
+		if p.flags&EXTENSION_FENCED_CODE != 0 {
+			if p.fencedCode(out, current, false) > 0 {
+				p.renderParagraph(out, data[:i])
+				return i
+			}
+		}
+
 		// if there's a definition list item, prev line is a definition term
 		if p.flags&EXTENSION_DEFINITION_LISTS != 0 {
 			if p.dliPrefix(current) != 0 {

--- a/block_test.go
+++ b/block_test.go
@@ -1065,6 +1065,78 @@ func TestFencedCodeBlock(t *testing.T) {
 	doTestsBlock(t, tests, EXTENSION_FENCED_CODE)
 }
 
+func TestFencedCodeInsideBlockquotes(t *testing.T) {
+	var tests = []string{
+		"> ```go\n" +
+			"package moo\n\n" +
+			"```\n",
+		`<blockquote>
+<pre><code class="language-go">package moo
+
+</code></pre>
+</blockquote>
+`,
+		// -------------------------------------------
+		"> foo\n" +
+			"> \n" +
+			"> ```go\n" +
+			"package moo\n" +
+			"```\n" +
+			"> \n" +
+			"> goo.\n",
+		`<blockquote>
+<p>foo</p>
+
+<pre><code class="language-go">package moo
+</code></pre>
+
+<p>goo.</p>
+</blockquote>
+`,
+		// -------------------------------------------
+		"> foo\n" +
+			"> \n" +
+			"> quote\n" +
+			"continues\n" +
+			"```\n",
+		"<blockquote>\n" +
+			"<p>foo</p>\n\n" +
+			"<p>quote\n" +
+			"continues\n" +
+			"```</p>\n" +
+			"</blockquote>\n",
+
+		"> foo\n" +
+			"> \n" +
+			"> ```go\n" +
+			"package moo\n" +
+			"```\n" +
+			"> \n" +
+			"> goo.\n" +
+			"> \n" +
+			"> ```go\n" +
+			"package zoo\n" +
+			"```\n" +
+			"> \n" +
+			"> woo.\n",
+		`<blockquote>
+<p>foo</p>
+
+<pre><code class="language-go">package moo
+</code></pre>
+
+<p>goo.</p>
+
+<pre><code class="language-go">package zoo
+</code></pre>
+
+<p>woo.</p>
+</blockquote>
+`,
+	}
+	doTestsBlock(t, tests, EXTENSION_FENCED_CODE)
+}
+
 func TestTable(t *testing.T) {
 	var tests = []string{
 		"a | b\n---|---\nc | d\n",

--- a/markdown.go
+++ b/markdown.go
@@ -393,7 +393,6 @@ func firstPass(p *parser, input []byte) []byte {
 		tabSize = TAB_SIZE_EIGHT
 	}
 	beg, end := 0, 0
-	lastLineWasBlank := false
 	lastFencedCodeBlockEnd := 0
 	for beg < len(input) { // iterate over lines
 		if end = isReference(p, input[beg:], tabSize); end > 0 {
@@ -405,16 +404,13 @@ func firstPass(p *parser, input []byte) []byte {
 			}
 
 			if p.flags&EXTENSION_FENCED_CODE != 0 {
-				// when last line was none blank and a fenced code block comes after
+				// track fenced code block boundaries to suppress tab expansion
+				// inside them:
 				if beg >= lastFencedCodeBlockEnd {
 					if i := p.fencedCode(&out, input[beg:], false); i > 0 {
-						if !lastLineWasBlank {
-							out.WriteByte('\n') // need to inject additional linebreak
-						}
 						lastFencedCodeBlockEnd = beg + i
 					}
 				}
-				lastLineWasBlank = end == beg
 			}
 
 			// add the line body if present

--- a/markdown.go
+++ b/markdown.go
@@ -385,7 +385,6 @@ func MarkdownOptions(input []byte, renderer Renderer, opts Options) []byte {
 // - expand tabs
 // - normalize newlines
 // - copy everything else
-// - add missing newlines before fenced code blocks
 func firstPass(p *parser, input []byte) []byte {
 	var out bytes.Buffer
 	tabSize := TAB_SIZE_DEFAULT


### PR DESCRIPTION
Improves fenced code block detection in paragraphs and blockquotes. Directly addresses #122, but refixes #45 along the way. More details in respective commit messages.