### PR TITLE
Fix nested footnotes

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -1000,6 +1000,33 @@ func TestFootnotesWithParameters(t *testing.T) {
 	doTestsInlineParam(t, tests, Options{Extensions: EXTENSION_FOOTNOTES}, HTML_FOOTNOTE_RETURN_LINKS, params)
 }
 
+func TestNestedFootnotes(t *testing.T) {
+	var tests = []string{
+		`Paragraph.[^fn1]
+
+[^fn1]:
+  Asterisk[^fn2]
+
+[^fn2]:
+  Obelisk`,
+		`<p>Paragraph.<sup class="footnote-ref" id="fnref:fn1"><a rel="footnote" href="#fn:fn1">1</a></sup></p>
+<div class="footnotes">
+
+<hr />
+
+<ol>
+<li id="fn:fn1">Asterisk<sup class="footnote-ref" id="fnref:fn2"><a rel="footnote" href="#fn:fn2">2</a></sup>
+</li>
+<li id="fn:fn2">Obelisk
+</li>
+</ol>
+</div>
+`,
+	}
+	doTestsInlineParam(t, tests, Options{Extensions: EXTENSION_FOOTNOTES}, 0,
+		HtmlRendererParameters{})
+}
+
 func TestInlineComments(t *testing.T) {
 	var tests = []string{
 		"Hello <!-- there ->\n",

--- a/markdown.go
+++ b/markdown.go
@@ -452,8 +452,9 @@ func secondPass(p *parser, input []byte) []byte {
 	if p.flags&EXTENSION_FOOTNOTES != 0 && len(p.notes) > 0 {
 		p.r.Footnotes(&output, func() bool {
 			flags := LIST_ITEM_BEGINNING_OF_LIST
-			for _, ref := range p.notes {
+			for i := 0; i < len(p.notes); i += 1 {
 				var buf bytes.Buffer
+				ref := p.notes[i]
 				if ref.hasBlock {
 					flags |= LIST_ITEM_CONTAINS_BLOCK
 					p.block(&buf, ref.title)

--- a/markdown.go
+++ b/markdown.go
@@ -20,6 +20,7 @@ package blackfriday
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"unicode/utf8"
 )
@@ -514,6 +515,11 @@ type reference struct {
 	noteId   int // 0 if not a footnote ref
 	hasBlock bool
 	text     []byte
+}
+
+func (r *reference) String() string {
+	return fmt.Sprintf("{link: %q, title: %q, text: %q, noteId: %d, hasBlock: %v}",
+		r.link, r.title, r.text, r.noteId, r.hasBlock)
 }
 
 // Check whether or not data starts with a reference link.

--- a/markdown.go
+++ b/markdown.go
@@ -454,8 +454,8 @@ func secondPass(p *parser, input []byte) []byte {
 		p.r.Footnotes(&output, func() bool {
 			flags := LIST_ITEM_BEGINNING_OF_LIST
 			for i := 0; i < len(p.notes); i += 1 {
-				var buf bytes.Buffer
 				ref := p.notes[i]
+				var buf bytes.Buffer
 				if ref.hasBlock {
 					flags |= LIST_ITEM_CONTAINS_BLOCK
 					p.block(&buf, ref.title)


### PR DESCRIPTION
This is both nasty and neat at the same time. All the code could handle nested footnotes just fine, the only place that was not working was the final loop that printed the list. The loop was in a range form, which couldn't account for another footnote being inserted while processing existing ones. Changing the loop to the iterative form solves that.

Fixes #193.