### PR TITLE
Fix footnote following an exclamation point

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -212,6 +212,11 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	var t linkType
 	if offset > 0 && data[offset-1] == '!' {
 		t = linkImg
+		// if footnotes extension is ON and we've seen "![^", then it's not an
+		// image, it's a deferred footnote:
+		if p.flags&EXTENSION_FOOTNOTES != 0 && len(data)-1 > offset && data[offset+1] == '^' {
+			t = linkDeferredFootnote
+		}
 	} else if p.flags&EXTENSION_FOOTNOTES != 0 {
 		if offset > 0 && data[offset-1] == '^' {
 			t = linkInlineFootnote

--- a/inline_test.go
+++ b/inline_test.go
@@ -969,6 +969,22 @@ what happens here
 </ol>
 </div>
 `,
+
+	`This is exciting![^fn1]
+
+[^fn1]: Fine print
+`,
+	`<p>This is exciting!<sup class="footnote-ref" id="fnref:fn1"><a rel="footnote" href="#fn:fn1">1</a></sup></p>
+<div class="footnotes">
+
+<hr />
+
+<ol>
+<li id="fn:fn1">Fine print
+</li>
+</ol>
+</div>
+`,
 }
 
 func TestFootnotes(t *testing.T) {


### PR DESCRIPTION
Link parser interpreted the sequence "![^foo]" as an image, but if
footnote extension is enabled, it's quite clear that it should be
interpreted as a footnote following something with an exclamation point
at the end.

Closes #194.