### PR TITLE
Fix regession: index out of range panic in reference link (#172, #173)

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -722,6 +722,10 @@ func TestReferenceLink(t *testing.T) {
 
 		"[link][ref]\n   [ref]: /url/",
 		"<p><a href=\"/url/\">link</a></p>\n",
+
+		// Issue 172 in blackfriday
+		"[]:<",
+		"<p>[]:&lt;</p>\n",
 	}
 	doLinkTestsInline(t, tests)
 }

--- a/markdown.go
+++ b/markdown.go
@@ -635,6 +635,9 @@ func scanLinkRef(p *parser, data []byte, i int) (linkOffset, linkEnd, titleOffse
 		i++
 	}
 	linkOffset = i
+	if i == len(data) {
+		return
+	}
 	for i < len(data) && data[i] != ' ' && data[i] != '\t' && data[i] != '\n' && data[i] != '\r' {
 		i++
 	}


### PR DESCRIPTION
The previous fix got reverted/removed by new commits.