### PR TITLE
Add EXTENSION_INLINE_CODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ _obj
 _test*
 markdown
 tags
+/.idea
+/blackfriday.iml

--- a/html.go
+++ b/html.go
@@ -482,8 +482,12 @@ func (options *Html) AutoLink(out *bytes.Buffer, link []byte, kind int) {
 	out.WriteString("</a>")
 }
 
-func (options *Html) CodeSpan(out *bytes.Buffer, text []byte) {
-	out.WriteString("<code>")
+func (options *Html) CodeSpan(out *bytes.Buffer, text []byte, lang string) {
+	if len(lang) > 0 {
+		out.WriteString("<code class=\"language-" + lang + "\">")
+	} else {
+		out.WriteString("<code>")
+	}
 	attrEscape(out, text)
 	out.WriteString("</code>")
 }

--- a/inline.go
+++ b/inline.go
@@ -147,7 +147,27 @@ func codeSpan(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 
 	// render the code span
 	if fBegin != fEnd {
-		p.r.CodeSpan(out, data[fBegin:fEnd])
+		langStart := 0
+		langEnd := 0
+
+		if p.flags&EXTENSION_INLINE_CODE != 0 {
+			// look for ~languagename~ at the beginning of the code string
+			if data[fBegin] == '~' {
+				idx := fBegin + 1
+				langStart = idx
+
+				for idx < fEnd && data[idx] != '~' {
+					idx++
+				}
+
+				if idx < fEnd {
+					langEnd = idx
+					fBegin = idx + 1
+				}
+			}
+		}
+
+		p.r.CodeSpan(out, data[fBegin:fEnd], string(data[langStart:langEnd]))
 	}
 
 	return end

--- a/latex.go
+++ b/latex.go
@@ -193,7 +193,7 @@ func (options *Latex) AutoLink(out *bytes.Buffer, link []byte, kind int) {
 	out.WriteString("}")
 }
 
-func (options *Latex) CodeSpan(out *bytes.Buffer, text []byte) {
+func (options *Latex) CodeSpan(out *bytes.Buffer, text []byte, lang string) {
 	out.WriteString("\\texttt{")
 	escapeSpecialChars(out, text)
 	out.WriteString("}")

--- a/markdown.go
+++ b/markdown.go
@@ -46,6 +46,7 @@ const (
 	EXTENSION_AUTO_HEADER_IDS                        // Create the header ID from the text
 	EXTENSION_BACKSLASH_LINE_BREAK                   // translate trailing backslashes into line breaks
 	EXTENSION_DEFINITION_LISTS                       // render definition lists
+	EXTENSION_INLINE_CODE				             // render inline code with language
 
 	commonHtmlFlags = 0 |
 		HTML_USE_XHTML |
@@ -179,7 +180,7 @@ type Renderer interface {
 
 	// Span-level callbacks
 	AutoLink(out *bytes.Buffer, link []byte, kind int)
-	CodeSpan(out *bytes.Buffer, text []byte)
+	CodeSpan(out *bytes.Buffer, text []byte, lang string)
 	DoubleEmphasis(out *bytes.Buffer, text []byte)
 	Emphasis(out *bytes.Buffer, text []byte)
 	Image(out *bytes.Buffer, link []byte, title []byte, alt []byte)


### PR DESCRIPTION
When enabled, func codeSpan looks for ~languagename~ at the beginning of the code string

and outputs `"<code class=\"language-" + languagename + "\">"`
instead of just `"<code>"`
for the HTML renderer. (Latex ignores it.)

This enables prettier syntax highlighting of inline code with JavaScript libraries like prism.js

For example Markdown
~~~
`~php~$var = 0;`
~~~

would produce the following HTML

~~~
<code class="language-php">$var = 0;</code>
~~~

I know this is a long shot as it introduces non-standard markdown syntax, but maybe you would like to consider it.

