### PR TITLE
Travis: Run gofmt -s, go vet, go test -race, add Go 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,30 @@
-# Travis CI (http://travis-ci.org/) is a continuous integration service for
-# open source projects. This file configures it to run unit tests for
-# blackfriday.
-
+sudo: false
 language: go
-
 go:
-    - 1.2
-    - 1.3
-    - 1.4
-    - 1.5
-
+  - 1.5.4
+  - 1.6.2
+  - tip
+matrix:
+  include:
+    - go: 1.2.2
+      script:
+        - go get -t -v ./...
+        - go test -v -race ./...
+    - go: 1.3.3
+      script:
+        - go get -t -v ./...
+        - go test -v -race ./...
+    - go: 1.4.3
+      script:
+        - go get -t -v ./...
+        - go test -v -race ./...
+  allow_failures:
+    - go: tip
+  fast_finish: true
 install:
-    - go get -d -t -v ./...
-    - go build -v ./...
-
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
-    - go test -v ./...
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Blackfriday [![Build Status](https://travis-ci.org/russross/blackfriday.svg?branch=master)](https://travis-ci.org/russross/blackfriday)
+Blackfriday [![Build Status](https://travis-ci.org/russross/blackfriday.svg?branch=master)](https://travis-ci.org/russross/blackfriday) [![GoDoc](https://godoc.org/github.com/russross/blackfriday?status.svg)](https://godoc.org/github.com/russross/blackfriday)
 ===========
 
 Blackfriday is a [Markdown][1] processor implemented in [Go][2]. It


### PR DESCRIPTION
Also make tip a fast-finish allowed failure. That way, if CI fails on tip due to a temporary issue with tip, it will not break build status. However, it's still possible to see tip build status by looking at CI details page.

Do not run go vet with Go 1.4 or older since it's not included in the standard library, and it's no longer available in external standard library.

Add godoc badge to README.md.