### PR TITLE
Avoid unneeded break statement.

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -938,7 +938,7 @@ func isMailtoAutoLink(data []byte) int {
 			nb++
 
 		case '-', '.', '_':
-			break
+			// Do nothing.
 
 		case '>':
 			if nb == 1 {


### PR DESCRIPTION
This is purely a style change with no behavior difference.

In Go (unlike most other languages), `case` statements in a `switch` don't need an explicit `break` statement, it happens by default. Adding it explicitly is possible, but has no effect (if it's the last statement in the `case`).

In this case, having the `break` statement hurts readability because it's hard to tell if it's a mistake, and the `break` was intended to break out of the outer `for` loop, rather than do nothing for the `switch` statement. So, remove it, to make it more clear that there is no bug here.