### PR TITLE
Add option LATEX_MATH, a.k.a. Mathjax math for HTML output

### DIFF
--- a/html.go
+++ b/html.go
@@ -947,3 +947,19 @@ func (options *Html) ensureUniqueHeaderID(id string) string {
 
 	return id
 }
+
+func (options *Html) Math(out *bytes.Buffer, equation []byte, inline bool) {
+	if inline {
+		out.WriteString("\\(")
+	} else {
+		out.WriteString("\\[")
+	}
+
+	attrEscape(out, equation)
+
+	if inline {
+		out.WriteString("\\)")
+	} else {
+		out.WriteString("\\]")
+	}
+}

--- a/inline.go
+++ b/inline.go
@@ -1146,3 +1146,49 @@ func helperTripleEmphasis(p *parser, out *bytes.Buffer, data []byte, offset int,
 	}
 	return 0
 }
+
+// LaTeX math surrounded by '$' or '$$'
+func math(p *parser, out *bytes.Buffer, data []byte, offset int) int {
+	data = data[offset:]
+
+	// inline math
+	if len(data) > 2 && data[1] != '$' {
+		// find the next '$'
+		end := 1
+		for end < len(data) && data[end] != '$' {
+			end++
+		}
+
+		// no matching delimiter?
+		if end == len(data) {
+			return 0
+		}
+
+		// render the inline math
+		if end != 0 {
+			p.r.Math(out, data[1:end], true)
+		}
+		return end + 1
+	}
+
+	// display math
+	if len(data) > 4 && data[1] == '$' && data[2] != '$' {
+		// find the next '$$'
+		end := 2
+		for end+1 < len(data) && (data[end] != '$' || data[end+1] != '$') {
+			end++
+		}
+
+		// no matching delimiter?
+		if end+1 == len(data) {
+			return 0
+		}
+
+		// render the display math
+		if end != 0 {
+			p.r.Math(out, data[2:end], false)
+		}
+		return end + 2
+	}
+	return 0
+}

--- a/latex.go
+++ b/latex.go
@@ -341,7 +341,7 @@ func (options *Latex) Math(out *bytes.Buffer, equation []byte, inline bool) {
 	out.Write(equation)
 
 	if inline {
-		out.WriteString("\\(")
+		out.WriteString("\\)")
 	} else {
 		out.WriteString("\\]")
 	}

--- a/latex.go
+++ b/latex.go
@@ -330,3 +330,19 @@ func (options *Latex) DocumentHeader(out *bytes.Buffer) {
 func (options *Latex) DocumentFooter(out *bytes.Buffer) {
 	out.WriteString("\n\\end{document}\n")
 }
+
+func (options *Latex) Math(out *bytes.Buffer, equation []byte, inline bool) {
+	if inline {
+		out.WriteString("\\(")
+	} else {
+		out.WriteString("\\[")
+	}
+
+	out.Write(equation)
+
+	if inline {
+		out.WriteString("\\(")
+	} else {
+		out.WriteString("\\]")
+	}
+}

--- a/markdown.go
+++ b/markdown.go
@@ -46,6 +46,7 @@ const (
 	EXTENSION_AUTO_HEADER_IDS                        // Create the header ID from the text
 	EXTENSION_BACKSLASH_LINE_BREAK                   // translate trailing backslashes into line breaks
 	EXTENSION_DEFINITION_LISTS                       // render definition lists
+	EXTENSION_LATEX_MATH                             // latex inline and display math surrounded by '$' or '$$'
 
 	commonHtmlFlags = 0 |
 		HTML_USE_XHTML |
@@ -189,6 +190,7 @@ type Renderer interface {
 	TripleEmphasis(out *bytes.Buffer, text []byte)
 	StrikeThrough(out *bytes.Buffer, text []byte)
 	FootnoteRef(out *bytes.Buffer, ref []byte, id int)
+	Math(out *bytes.Buffer, equation []byte, inline bool)
 
 	// Low-level callbacks
 	Entity(out *bytes.Buffer, entity []byte)
@@ -378,6 +380,10 @@ func MarkdownOptions(input []byte, renderer Renderer, opts Options) []byte {
 
 	if extensions&EXTENSION_FOOTNOTES != 0 {
 		p.notes = make([]*reference, 0)
+	}
+
+	if extensions&EXTENSION_LATEX_MATH != 0 {
+		p.inlineCallback['$'] = math
 	}
 
 	first := firstPass(p, input)


### PR DESCRIPTION
Make parsing of '$' and '$$' special. It makes it possible to typeset beautiful math using TeX-and-friends syntax. It can be rendered on an HTML page with 

```html
<script type="text/javascript" async="" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
```  

Credits go to Yuntan for this patch, I just fixed the closing delimiter.