### PR TITLE
Add Math extension

### DIFF
--- a/block.go
+++ b/block.go
@@ -194,6 +194,13 @@ func (p *parser) block(data []byte) {
 			}
 		}
 
+		if p.flags&LaTeXMath != 0 {
+			if i := p.latexMath(data); i > 0 {
+				data = data[i:]
+				continue
+			}
+		}
+
 		// anything else must look like a normal paragraph
 		// note: this finds underlined headers, too
 		data = data[p.paragraph(data):]
@@ -1484,6 +1491,29 @@ func (p *parser) paragraph(data []byte) int {
 
 	p.renderParagraph(data[:i])
 	return i
+}
+
+func (p *parser) latexMath(data []byte) int {
+	if len(data) > 4 && data[0] == '$' && data[1] == '$' && data[2] != '$' {
+		// find the next '$$'
+		end := 2
+		for end+1 < len(data) && (data[end] != '$' || data[end+1] != '$') {
+			end++
+		}
+
+		// no matching delimiter?
+		if end+1 == len(data) {
+			return 0
+		}
+
+		// render the display math
+		if end != 0 {
+			container := p.addChild(MathBlock, 0)
+			container.Literal = data[2:end]
+		}
+		return end + 2
+	}
+	return 0
 }
 
 func skipChar(data []byte, start int, char byte) int {

--- a/block_test.go
+++ b/block_test.go
@@ -1579,3 +1579,20 @@ func TestCompletePage(t *testing.T) {
 	}
 	doTestsParam(t, tests, TestParams{HTMLFlags: UseXHTML | CompletePage})
 }
+
+func TestMathBlock(t *testing.T) {
+	var tests = []string{
+		"$$f(x) = x^2$$\n",
+		"\\[f(x) = x^2\\]\n",
+
+		"$$x<y$$\n",
+		"\\[x&lt;y\\]\n",
+
+		"$$x^2\n",
+		"<p>$$x^2</p>\n",
+
+		"x^2$$\n",
+		"<p>x^2$$</p>\n",
+	}
+	doTestsBlock(t, tests, LaTeXMath)
+}

--- a/html.go
+++ b/html.go
@@ -710,6 +710,16 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 			r.out(w, tag("/tr", nil, false))
 			r.cr(w)
 		}
+	case Math:
+		r.out(w, []byte("\\("))
+		r.out(w, escCode(node.Literal, false))
+		r.out(w, []byte("\\)"))
+	case MathBlock:
+		r.out(w, []byte("\\["))
+		r.out(w, escCode(node.Literal, false))
+		r.out(w, []byte("\\]"))
+		r.cr(w)
+
 	default:
 		panic("Unknown node type " + node.Type.String())
 	}

--- a/html.go
+++ b/html.go
@@ -124,7 +124,7 @@ func (w *HTMLWriter) Newline() {
 
 // NewHTMLRenderer creates and configures an HTMLRenderer object, which
 // satisfies the Renderer interface.
-func NewHTMLRenderer(params HTMLRendererParameters) Renderer {
+func NewHTMLRenderer(params HTMLRendererParameters) *HTMLRenderer {
 	// configure the rendering engine
 	closeTag := htmlClose
 	if params.Flags&UseXHTML != 0 {

--- a/inline.go
+++ b/inline.go
@@ -1234,6 +1234,35 @@ func helperTripleEmphasis(p *parser, data []byte, offset int, c byte) int {
 	return 0
 }
 
+// LaTeX math surrounded by '$' or '$$'
+func math(p *parser, data []byte, offset int) int {
+	data = data[offset:]
+
+	// inline math
+	if len(data) > 2 && data[1] != '$' {
+		// find the next '$'
+		end := 1
+		for end < len(data) && data[end] != '$' {
+			end++
+		}
+
+		// no matching delimiter?
+		if end == len(data) {
+			return 0
+		}
+
+		// render the inline math
+		if end != 0 {
+			math := NewNode(Math)
+			math.Literal = data[1:end]
+			p.currBlock.appendChild(math)
+		}
+		return end + 1
+	}
+
+	return 0
+}
+
 func text(s []byte) *Node {
 	node := NewNode(Text)
 	node.Literal = s

--- a/inline_test.go
+++ b/inline_test.go
@@ -1168,3 +1168,11 @@ func TestSkipHTML(t *testing.T) {
 		"<p>text inline html more text</p>\n",
 	}, TestParams{HTMLFlags: SkipHTML})
 }
+
+func TestMathInline(t *testing.T) {
+	var tests = []string{
+		"$f(x) = x^2$\n",
+		"<p>\\(f(x) = x^2\\)</p>\n",
+	}
+	doTestsParam(t, tests, TestParams{Options: Options{Extensions: LaTeXMath}})
+}

--- a/markdown.go
+++ b/markdown.go
@@ -56,6 +56,7 @@ const (
 	SmartypantsAngledQuotes                        // Enable angled double quotes (with Smartypants) for double quotes rendering
 	TOC                                            // Generate a table of contents
 	OmitContents                                   // Skip the main contents (for a standalone table of contents)
+	LaTeXMath                                      // LaTeX inline and display math surrounded by '$' or '$$'
 
 	CommonHtmlFlags HTMLFlags = UseXHTML
 
@@ -396,6 +397,10 @@ func Parse(input []byte, opts Options) *Node {
 
 	if extensions&Footnotes != 0 {
 		p.notes = make([]*reference, 0)
+	}
+
+	if extensions&LaTeXMath != 0 {
+		p.inlineCallback['$'] = math
 	}
 
 	first := firstPass(p, input)

--- a/markdown.go
+++ b/markdown.go
@@ -439,29 +439,27 @@ func (p *parser) generateTOC() {
 	p.doc.Walk(func(node *Node, entering bool) WalkStatus {
 		if entering && node.Type == Header {
 			if node.Level > currentLevel {
-				currentLevel++
-				newList := NewNode(List)
+				currentLevel = node.Level
+				listNode = NewNode(List)
 				if lastItem != nil {
-					lastItem.appendChild(newList)
-					listNode = newList
+					lastItem.appendChild(listNode)
 				} else {
-					listNode = newList
 					topList = listNode
 				}
-			}
-			if node.Level < currentLevel {
+			} else if node.Level < currentLevel {
+				currentLevel = node.Level
 				finalizeList(listNode)
 				lastItem = listNode.Parent
 				listNode = lastItem.Parent
 			}
 			node.HeaderID = fmt.Sprintf("toc_%d", headerCount)
 			headerCount++
-			lastItem = NewNode(Item)
-			listNode.appendChild(lastItem)
 			anchorNode := NewNode(Link)
 			anchorNode.Destination = []byte("#" + node.HeaderID)
-			lastItem.appendChild(anchorNode)
 			anchorNode.appendChild(text(node.FirstChild.Literal))
+			lastItem = NewNode(Item)
+			lastItem.appendChild(anchorNode)
+			listNode.appendChild(lastItem)
 		}
 		return GoToNext
 	})

--- a/node.go
+++ b/node.go
@@ -32,6 +32,8 @@ const (
 	TableHead
 	TableBody
 	TableRow
+	Math
+	MathBlock
 )
 
 var nodeTypeNames = []string{
@@ -59,6 +61,8 @@ var nodeTypeNames = []string{
 	TableHead:      "TableHead",
 	TableBody:      "TableBody",
 	TableRow:       "TableRow",
+	Math:           "Math",
+	MathBlock:      "MathBlock",
 }
 
 func (t NodeType) String() string {

--- a/node.go
+++ b/node.go
@@ -314,6 +314,10 @@ func (nw *NodeWalker) resumeAt(node *Node, entering bool) (*Node, bool) {
 	return nw.next()
 }
 
+func (ast *Node) String() string {
+	return dumpString(ast)
+}
+
 func dump(ast *Node) {
 	fmt.Println(dumpString(ast))
 }


### PR DESCRIPTION
It enables direct math support in LaTeX, as well as HTML with MathJax.

I believe this feature to be a popular demand. See #256 and #220.

This is a request for comments, as I am quite new to Blackfriday.
I haven't written many tests yet, I'm waiting for your comments.

The main point of contention would be the math delimiter, being '$' and '$$' at the moment. This obviously creates a conflict with a regular use of the dollar signe. Both MathJax and LaTeX use '\(' and '\['. I am not sure how we can use those in Markdown because of the conflict with the 'escape' rules.