### PR TITLE
v2: Add Math extension

### DIFF
--- a/block.go
+++ b/block.go
@@ -115,7 +115,7 @@ func (p *parser) block(data []byte) {
 		// }
 		// ```
 		if p.flags&FencedCode != 0 {
-			if i := p.fencedCode(data, true); i > 0 {
+			if i := p.fencedCodeBlock(data, true); i > 0 {
 				data = data[i:]
 				continue
 			}
@@ -526,7 +526,7 @@ func (p *parser) htmlFindEnd(tag string, data []byte) int {
 	return i + skip
 }
 
-func (p *parser) isEmpty(data []byte) int {
+func (*parser) isEmpty(data []byte) int {
 	// it is okay to call isEmpty on an empty buffer
 	if len(data) == 0 {
 		return 0
@@ -541,7 +541,7 @@ func (p *parser) isEmpty(data []byte) int {
 	return i + 1
 }
 
-func (p *parser) isHRule(data []byte) bool {
+func (*parser) isHRule(data []byte) bool {
 	i := 0
 
 	// skip up to three spaces
@@ -570,21 +570,24 @@ func (p *parser) isHRule(data []byte) bool {
 	return n >= 3
 }
 
-func (p *parser) isFencedCode(data []byte, syntax **string, oldmarker string) (skip int, marker string) {
+// isFenceLine checks if there's a fence line (e.g., ``` or ``` go) at the beginning of data,
+// and returns the end index if so, or 0 otherwise. It also returns the marker found.
+// If syntax is not nil, it gets set to the syntax specified in the fence line.
+// A final newline is mandatory to recognize the fence line, unless newlineOptional is true.
+func isFenceLine(data []byte, syntax *string, oldmarker string, newlineOptional bool) (end int, marker string) {
 	i, size := 0, 0
-	skip = 0
 
 	// skip up to three spaces
 	for i < len(data) && i < 3 && data[i] == ' ' {
 		i++
 	}
-	if i >= len(data) {
-		return
-	}
 
 	// check for the marker characters: ~ or `
+	if i >= len(data) {
+		return 0, ""
+	}
 	if data[i] != '~' && data[i] != '`' {
-		return
+		return 0, ""
 	}
 
 	c := data[i]
@@ -595,27 +598,28 @@ func (p *parser) isFencedCode(data []byte, syntax **string, oldmarker string) (s
 		i++
 	}
 
-	if i >= len(data) {
-		return
-	}
-
 	// the marker char must occur at least 3 times
 	if size < 3 {
-		return
+		return 0, ""
 	}
 	marker = string(data[i-size : i])
 
 	// if this is the end marker, it must match the beginning marker
 	if oldmarker != "" && marker != oldmarker {
-		return
+		return 0, ""
 	}
 
+	// TODO(shurcooL): It's probably a good idea to simplify the 2 code paths here
+	// into one, always get the syntax, and discard it if the caller doesn't care.
 	if syntax != nil {
 		syn := 0
 		i = skipChar(data, i, ' ')
 
 		if i >= len(data) {
-			return
+			if newlineOptional && i == len(data) {
+				return i, marker
+			}
+			return 0, ""
 		}
 
 		syntaxStart := i
@@ -630,7 +634,7 @@ func (p *parser) isFencedCode(data []byte, syntax **string, oldmarker string) (s
 			}
 
 			if i >= len(data) || data[i] != '}' {
-				return
+				return 0, ""
 			}
 
 			// strip all whitespace at the beginning and the end
@@ -652,37 +656,40 @@ func (p *parser) isFencedCode(data []byte, syntax **string, oldmarker string) (s
 			}
 		}
 
-		language := string(data[syntaxStart : syntaxStart+syn])
-		*syntax = &language
+		*syntax = string(data[syntaxStart : syntaxStart+syn])
 	}
 
 	i = skipChar(data, i, ' ')
 	if i >= len(data) || data[i] != '\n' {
-		return
+		if newlineOptional && i == len(data) {
+			return i, marker
+		}
+		return 0, ""
 	}
 
-	skip = i + 1
-	return
+	return i + 1, marker // Take newline into account.
 }
 
-func (p *parser) fencedCode(data []byte, doRender bool) int {
-	var lang *string
-	beg, marker := p.isFencedCode(data, &lang, "")
+// fencedCodeBlock returns the end index if data contains a fenced code block at the beginning,
+// or 0 otherwise. It writes to out if doRender is true, otherwise it has no side effects.
+// If doRender is true, a final newline is mandatory to recognize the fenced code block.
+func (p *parser) fencedCodeBlock(data []byte, doRender bool) int {
+	var syntax string
+	beg, marker := isFenceLine(data, &syntax, "", false)
 	if beg == 0 || beg >= len(data) {
 		return 0
 	}
 
 	var work bytes.Buffer
-	if lang != nil {
-		work.Write([]byte(*lang))
-		work.WriteByte('\n')
-	}
+	work.Write([]byte(syntax))
+	work.WriteByte('\n')
 
 	for {
 		// safe to assume beg < len(data)
 
 		// check for the end of the code block
-		fenceEnd, _ := p.isFencedCode(data[beg:], nil, marker)
+		newlineOptional := !doRender
+		fenceEnd, _ := isFenceLine(data[beg:], nil, marker, newlineOptional)
 		if fenceEnd != 0 {
 			beg += fenceEnd
 			break
@@ -702,11 +709,6 @@ func (p *parser) fencedCode(data []byte, doRender bool) int {
 		}
 		beg = end
 	}
-
-	//syntax := ""
-	//if lang != nil {
-	//	syntax = *lang
-	//}
 
 	if doRender {
 		block := p.addBlock(CodeBlock, work.Bytes()) // TODO: get rid of temp buffer
@@ -972,7 +974,7 @@ func (p *parser) quote(data []byte) int {
 		// irregardless of any contents inside it
 		for data[end] != '\n' {
 			if p.flags&FencedCode != 0 {
-				if i := p.fencedCode(data[end:], false); i > 0 {
+				if i := p.fencedCodeBlock(data[end:], false); i > 0 {
 					// -1 to compensate for the extra end++ after the loop:
 					end += i - 1
 					break
@@ -1451,7 +1453,7 @@ func (p *parser) paragraph(data []byte) int {
 
 		// if there's a fenced code block, paragraph is over
 		if p.flags&FencedCode != 0 {
-			if p.fencedCode(current, false) > 0 {
+			if p.fencedCodeBlock(current, false) > 0 {
 				p.renderParagraph(data[:i])
 				return i
 			}

--- a/block.go
+++ b/block.go
@@ -22,13 +22,13 @@ import (
 )
 
 const (
-	Entity    = "&(?:#x[a-f0-9]{1,8}|#[0-9]{1,8}|[a-z][a-z0-9]{1,31});"
-	Escapable = "[!\"#$%&'()*+,./:;<=>?@[\\\\\\]^_`{|}~-]"
+	charEntity = "&(?:#x[a-f0-9]{1,8}|#[0-9]{1,8}|[a-z][a-z0-9]{1,31});"
+	escapable  = "[!\"#$%&'()*+,./:;<=>?@[\\\\\\]^_`{|}~-]"
 )
 
 var (
 	reBackslashOrAmp      = regexp.MustCompile("[\\&]")
-	reEntityOrEscapedChar = regexp.MustCompile("(?i)\\\\" + Escapable + "|" + Entity)
+	reEntityOrEscapedChar = regexp.MustCompile("(?i)\\\\" + escapable + "|" + charEntity)
 	reTrailingWhitespace  = regexp.MustCompile("(\n *)+$")
 )
 
@@ -279,9 +279,8 @@ func (p *parser) isUnderlinedHeader(data []byte) int {
 		i = skipChar(data, i, ' ')
 		if data[i] == '\n' {
 			return 1
-		} else {
-			return 0
 		}
+		return 0
 	}
 
 	// test of level 2 header
@@ -290,9 +289,8 @@ func (p *parser) isUnderlinedHeader(data []byte) int {
 		i = skipChar(data, i, ' ')
 		if data[i] == '\n' {
 			return 2
-		} else {
-			return 0
 		}
+		return 0
 	}
 
 	return 0
@@ -414,13 +412,13 @@ func (p *parser) html(data []byte, doRender bool) int {
 		for end > 0 && data[end-1] == '\n' {
 			end--
 		}
-		finalizeHtmlBlock(p.addBlock(HTMLBlock, data[:end]))
+		finalizeHTMLBlock(p.addBlock(HTMLBlock, data[:end]))
 	}
 
 	return i
 }
 
-func finalizeHtmlBlock(block *Node) {
+func finalizeHTMLBlock(block *Node) {
 	block.Literal = reTrailingWhitespace.ReplaceAll(block.content, []byte{})
 	block.content = []byte{}
 }
@@ -438,7 +436,7 @@ func (p *parser) htmlComment(data []byte, doRender bool) int {
 				end--
 			}
 			block := p.addBlock(HTMLBlock, data[:end])
-			finalizeHtmlBlock(block)
+			finalizeHTMLBlock(block)
 		}
 		return size
 	}
@@ -470,7 +468,7 @@ func (p *parser) htmlHr(data []byte, doRender bool) int {
 				for end > 0 && data[end-1] == '\n' {
 					end--
 				}
-				finalizeHtmlBlock(p.addBlock(HTMLBlock, data[:end]))
+				finalizeHTMLBlock(p.addBlock(HTMLBlock, data[:end]))
 			}
 			return size
 		}
@@ -729,9 +727,8 @@ func unescapeChar(str []byte) []byte {
 func unescapeString(str []byte) []byte {
 	if reBackslashOrAmp.Match(str) {
 		return reEntityOrEscapedChar.ReplaceAllFunc(str, unescapeChar)
-	} else {
-		return str
 	}
+	return str
 }
 
 func finalizeCodeBlock(block *Node) {

--- a/block.go
+++ b/block.go
@@ -427,7 +427,7 @@ func finalizeHtmlBlock(block *Node) {
 
 // HTML comment, lax form
 func (p *parser) htmlComment(data []byte, doRender bool) int {
-	i := p.inlineHtmlComment(data)
+	i := p.inlineHTMLComment(data)
 	// needs to end with a blank line
 	if j := p.isEmpty(data[i:]); j > 0 {
 		size := i + j

--- a/block_test.go
+++ b/block_test.go
@@ -1011,6 +1011,12 @@ func TestFencedCodeBlock(t *testing.T) {
 
 		"Some text before a fenced code block\n``` oz\ncode blocks breakup paragraphs\n```\nSome text in between\n``` oz\nmultiple code blocks work okay\n```\nAnd some text after a fenced code block",
 		"<p>Some text before a fenced code block</p>\n\n<pre><code class=\"language-oz\">code blocks breakup paragraphs\n</code></pre>\n\n<p>Some text in between</p>\n\n<pre><code class=\"language-oz\">multiple code blocks work okay\n</code></pre>\n\n<p>And some text after a fenced code block</p>\n",
+
+		"```\n[]:()\n```\n",
+		"<pre><code>[]:()\n</code></pre>\n",
+
+		"```\n[]:()\n[]:)\n[]:(\n[]:x\n[]:testing\n[:testing\n\n[]:\nlinebreak\n[]()\n\n[]:\n[]()\n```",
+		"<pre><code>[]:()\n[]:)\n[]:(\n[]:x\n[]:testing\n[:testing\n\n[]:\nlinebreak\n[]()\n\n[]:\n[]()\n</code></pre>\n",
 	}
 	doTestsBlock(t, tests, FencedCode)
 }
@@ -1578,4 +1584,75 @@ func TestCompletePage(t *testing.T) {
 `,
 	}
 	doTestsParam(t, tests, TestParams{HTMLFlags: UseXHTML | CompletePage})
+}
+
+func TestIsFenceLine(t *testing.T) {
+	tests := []struct {
+		data            []byte
+		syntaxRequested bool
+		newlineOptional bool
+		wantEnd         int
+		wantMarker      string
+		wantSyntax      string
+	}{
+		{
+			data:    []byte("```"),
+			wantEnd: 0,
+		},
+		{
+			data:       []byte("```\nstuff here\n"),
+			wantEnd:    4,
+			wantMarker: "```",
+		},
+		{
+			data:            []byte("```\nstuff here\n"),
+			syntaxRequested: true,
+			wantEnd:         4,
+			wantMarker:      "```",
+		},
+		{
+			data:    []byte("stuff here\n```\n"),
+			wantEnd: 0,
+		},
+		{
+			data:            []byte("```"),
+			newlineOptional: true,
+			wantEnd:         3,
+			wantMarker:      "```",
+		},
+		{
+			data:            []byte("```"),
+			syntaxRequested: true,
+			newlineOptional: true,
+			wantEnd:         3,
+			wantMarker:      "```",
+		},
+		{
+			data:            []byte("``` go"),
+			syntaxRequested: true,
+			newlineOptional: true,
+			wantEnd:         6,
+			wantMarker:      "```",
+			wantSyntax:      "go",
+		},
+	}
+
+	for _, test := range tests {
+		var syntax *string
+		if test.syntaxRequested {
+			syntax = new(string)
+		}
+		end, marker := isFenceLine(test.data, syntax, "```", test.newlineOptional)
+		if got, want := end, test.wantEnd; got != want {
+			t.Errorf("got end %v, want %v", got, want)
+		}
+		if got, want := marker, test.wantMarker; got != want {
+			t.Errorf("got marker %q, want %q", got, want)
+		}
+		if test.syntaxRequested {
+			if got, want := *syntax, test.wantSyntax; got != want {
+				t.Errorf("got syntax %q, want %q", got, want)
+			}
+		}
+	}
 }

--- a/block_test.go
+++ b/block_test.go
@@ -1572,7 +1572,7 @@ func TestCompletePage(t *testing.T) {
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <title></title>
-  <meta name="GENERATOR" content="Blackfriday Markdown Processor v1.4" />
+  <meta name="GENERATOR" content="Blackfriday Markdown Processor v2.0" />
   <meta charset="utf-8" />
 </head>
 <body>

--- a/block_test.go
+++ b/block_test.go
@@ -1656,3 +1656,20 @@ func TestIsFenceLine(t *testing.T) {
 		}
 	}
 }
+
+func TestMathBlock(t *testing.T) {
+	var tests = []string{
+		"$$f(x) = x^2$$\n",
+		"\\[f(x) = x^2\\]\n",
+
+		"$$x<y$$\n",
+		"\\[x&lt;y\\]\n",
+
+		"$$x^2\n",
+		"<p>$$x^2</p>\n",
+
+		"x^2$$\n",
+		"<p>x^2$$</p>\n",
+	}
+	doTestsBlock(t, tests, LaTeXMath)
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -49,6 +49,17 @@ func runMarkdown(input string, params TestParams) string {
 	return string(Markdown([]byte(input), renderer, params.Options))
 }
 
+// doTests runs full document tests using MarkdownCommon configuration.
+func doTests(t *testing.T, tests []string) {
+	doTestsParam(t, tests, TestParams{
+		Options: DefaultOptions,
+		HTMLRendererParameters: HTMLRendererParameters{
+			Flags:      CommonHtmlFlags,
+			Extensions: CommonExtensions,
+		},
+	})
+}
+
 func doTestsBlock(t *testing.T, tests []string, extensions Extensions) {
 	doTestsParam(t, tests, TestParams{
 		Options:   Options{Extensions: extensions},

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -54,7 +54,7 @@ func doTests(t *testing.T, tests []string) {
 	doTestsParam(t, tests, TestParams{
 		Options: DefaultOptions,
 		HTMLRendererParameters: HTMLRendererParameters{
-			Flags:      CommonHtmlFlags,
+			Flags:      CommonHTMLFlags,
 			Extensions: CommonExtensions,
 		},
 	})
@@ -106,7 +106,7 @@ func doLinkTestsInline(t *testing.T, tests []string) {
 		HTMLRendererParameters: params,
 	})
 	doTestsInlineParam(t, transformTests, TestParams{
-		HTMLFlags:              CommonHtmlFlags,
+		HTMLFlags:              CommonHTMLFlags,
 		HTMLRendererParameters: params,
 	})
 }

--- a/html.go
+++ b/html.go
@@ -727,7 +727,7 @@ func (r *HTMLRenderer) writeDocumentHeader(w *bytes.Buffer, sr *SPRenderer) {
 	}
 	w.WriteString("</title>\n")
 	w.WriteString("  <meta name=\"GENERATOR\" content=\"Blackfriday Markdown Processor v")
-	w.WriteString(VERSION)
+	w.WriteString(Version)
 	w.WriteString("\"")
 	w.WriteString(ending)
 	w.WriteString(">\n")

--- a/html.go
+++ b/html.go
@@ -102,7 +102,6 @@ type HTMLRenderer struct {
 	// Track header IDs to prevent ID collision in a single generation.
 	headerIDs map[string]int
 
-	w             HTMLWriter
 	lastOutputLen int
 	disableTags   int
 }
@@ -111,16 +110,6 @@ const (
 	xhtmlClose = " />"
 	htmlClose  = ">"
 )
-
-type HTMLWriter struct {
-	bytes.Buffer
-}
-
-// Writes out a newline if the output is not pristine. Used at the beginning of
-// every rendering func
-func (w *HTMLWriter) Newline() {
-	w.WriteByte('\n')
-}
 
 // NewHTMLRenderer creates and configures an HTMLRenderer object, which
 // satisfies the Renderer interface.
@@ -135,13 +124,11 @@ func NewHTMLRenderer(params HTMLRendererParameters) Renderer {
 		params.FootnoteReturnLinkContents = `<sup>[return]</sup>`
 	}
 
-	var writer HTMLWriter
 	return &HTMLRenderer{
 		HTMLRendererParameters: params,
 
 		closeTag:  closeTag,
 		headerIDs: make(map[string]int),
-		w:         writer,
 	}
 }
 

--- a/html.go
+++ b/html.go
@@ -93,12 +93,6 @@ type HTMLRenderer struct {
 
 	closeTag string // how to end singleton tags: either " />" or ">"
 
-	// table of contents data
-	tocMarker    int
-	headerCount  int
-	currentLevel int
-	toc          bytes.Buffer
-
 	// Track header IDs to prevent ID collision in a single generation.
 	headerIDs map[string]int
 

--- a/html.go
+++ b/html.go
@@ -107,7 +107,7 @@ const (
 
 // NewHTMLRenderer creates and configures an HTMLRenderer object, which
 // satisfies the Renderer interface.
-func NewHTMLRenderer(params HTMLRendererParameters) Renderer {
+func NewHTMLRenderer(params HTMLRendererParameters) *HTMLRenderer {
 	// configure the rendering engine
 	closeTag := htmlClose
 	if params.Flags&UseXHTML != 0 {

--- a/html.go
+++ b/html.go
@@ -698,6 +698,16 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 			r.out(w, tag("/tr", nil, false))
 			r.cr(w)
 		}
+	case Math:
+		r.out(w, []byte("\\("))
+		r.out(w, escCode(node.Literal))
+		r.out(w, []byte("\\)"))
+	case MathBlock:
+		r.out(w, []byte("\\["))
+		r.out(w, escCode(node.Literal))
+		r.out(w, []byte("\\]"))
+		r.cr(w)
+
 	default:
 		panic("Unknown node type " + node.Type.String())
 	}

--- a/html.go
+++ b/html.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 )
 
+// HTMLFlags control optional behavior of HTML renderer.
 type HTMLFlags int
 
 // HTML renderer configuration options.
@@ -63,6 +64,8 @@ var (
 	htmlTagRe = regexp.MustCompile("(?i)^" + HTMLTag)
 )
 
+// HTMLRendererParameters is a collection of supplementary parameters tweaking
+// the behavior of various parts of HTML renderer.
 type HTMLRendererParameters struct {
 	// Prepend this text to each relative URL.
 	AbsolutePrefix string
@@ -126,8 +129,8 @@ func NewHTMLRenderer(params HTMLRendererParameters) *HTMLRenderer {
 	}
 }
 
-func isHtmlTag(tag []byte, tagname string) bool {
-	found, _ := findHtmlTagPos(tag, tagname)
+func isHTMLTag(tag []byte, tagname string) bool {
+	found, _ := findHTMLTagPos(tag, tagname)
 	return found
 }
 
@@ -154,7 +157,7 @@ func skipUntilCharIgnoreQuotes(html []byte, start int, char byte) int {
 	return start
 }
 
-func findHtmlTagPos(tag []byte, tagname string) (bool, int) {
+func findHTMLTagPos(tag []byte, tagname string) (bool, int) {
 	i := 0
 	if i < len(tag) && tag[0] != '<' {
 		return false, -1
@@ -384,6 +387,16 @@ func (r *HTMLRenderer) cr(w io.Writer) {
 	}
 }
 
+// RenderNode is a default renderer of a single node of a syntax tree. For
+// block nodes it will be called twice: first time with entering=true, second
+// time with entering=false, so that it could know when it's working on an open
+// tag and when on close. It writes the result to w.
+//
+// The return value is a way to tell the calling walker to adjust its walk
+// pattern: e.g. it can terminate the traversal by returning Terminate. Or it
+// can ask the walker to skip a subtree of this node by returning SkipChildren.
+// The typical behavior is to return GoToNext, which asks for the usual
+// traversal to the next node.
 func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkStatus {
 	attrs := []string{}
 	switch node.Type {
@@ -420,7 +433,7 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 		if r.Flags&SkipHTML != 0 {
 			break
 		}
-		if r.Flags&SkipStyle != 0 && isHtmlTag(node.Literal, "style") {
+		if r.Flags&SkipStyle != 0 && isHTMLTag(node.Literal, "style") {
 			break
 		}
 		//if options.safe {
@@ -739,6 +752,7 @@ func (r *HTMLRenderer) writeDocumentFooter(w *bytes.Buffer) {
 	w.WriteString("\n</body>\n</html>\n")
 }
 
+// Render walks the specified syntax (sub)tree and returns a HTML document.
 func (r *HTMLRenderer) Render(ast *Node) []byte {
 	//println("render_Blackfriday")
 	//dump(ast)

--- a/html.go
+++ b/html.go
@@ -748,7 +748,7 @@ func (r *HTMLRenderer) writeDocumentHeader(w *bytes.Buffer, sr *SPRenderer) {
 	w.WriteString(">\n")
 	if r.CSS != "" {
 		w.WriteString("  <link rel=\"stylesheet\" type=\"text/css\" href=\"")
-		attrEscape([]byte(r.CSS))
+		w.Write(attrEscape([]byte(r.CSS)))
 		w.WriteString("\"")
 		w.WriteString(ending)
 		w.WriteString(">\n")

--- a/inline.go
+++ b/inline.go
@@ -1234,6 +1234,35 @@ func helperTripleEmphasis(p *parser, data []byte, offset int, c byte) int {
 	return 0
 }
 
+// LaTeX math surrounded by '$' or '$$'
+func math(p *parser, data []byte, offset int) int {
+	data = data[offset:]
+
+	// inline math
+	if len(data) > 2 && data[1] != '$' {
+		// find the next '$'
+		end := 1
+		for end < len(data) && data[end] != '$' {
+			end++
+		}
+
+		// no matching delimiter?
+		if end == len(data) {
+			return 0
+		}
+
+		// render the inline math
+		if end != 0 {
+			math := NewNode(Math)
+			math.Literal = data[1:end]
+			p.currBlock.appendChild(math)
+		}
+		return end + 1
+	}
+
+	return 0
+}
+
 func text(s []byte) *Node {
 	node := NewNode(Text)
 	node.Literal = s

--- a/inline.go
+++ b/inline.go
@@ -285,7 +285,7 @@ func link(p *parser, data []byte, offset int) int {
 
 	var (
 		i                       = 1
-		noteId                  int
+		noteID                  int
 		title, link, altContent []byte
 		textHasNl               = false
 	)
@@ -501,7 +501,7 @@ func link(p *parser, data []byte, offset int) int {
 
 		if t == linkInlineFootnote {
 			// create a new reference
-			noteId = len(p.notes) + 1
+			noteID = len(p.notes) + 1
 
 			var fragment []byte
 			if len(id) > 0 {
@@ -512,11 +512,11 @@ func link(p *parser, data []byte, offset int) int {
 				}
 				copy(fragment, slugify(id))
 			} else {
-				fragment = append([]byte("footnote-"), []byte(strconv.Itoa(noteId))...)
+				fragment = append([]byte("footnote-"), []byte(strconv.Itoa(noteID))...)
 			}
 
 			ref := &reference{
-				noteId:   noteId,
+				noteID:   noteID,
 				hasBlock: false,
 				link:     fragment,
 				title:    id,
@@ -534,7 +534,7 @@ func link(p *parser, data []byte, offset int) int {
 			}
 
 			if t == linkDeferredFootnote {
-				lr.noteId = len(p.notes) + 1
+				lr.noteID = len(p.notes) + 1
 				p.notes = append(p.notes, lr)
 			}
 
@@ -542,7 +542,7 @@ func link(p *parser, data []byte, offset int) int {
 			link = lr.link
 			// if inline footnote, title == footnote contents
 			title = lr.title
-			noteId = lr.noteId
+			noteID = lr.noteID
 		}
 
 		// rewind the whitespace
@@ -596,7 +596,7 @@ func link(p *parser, data []byte, offset int) int {
 		linkNode := NewNode(Link)
 		linkNode.Destination = link
 		linkNode.Title = title
-		linkNode.NoteID = noteId
+		linkNode.NoteID = noteID
 		p.currBlock.appendChild(linkNode)
 		if t == linkInlineFootnote {
 			i++

--- a/inline.go
+++ b/inline.go
@@ -638,23 +638,32 @@ func stripMailto(link []byte) []byte {
 	}
 }
 
+// autolinkType specifies a kind of autolink that gets detected.
+type autolinkType int
+
+// These are the possible flag values for the autolink renderer.
+const (
+	notAutolink autolinkType = iota
+	normalAutolink
+	emailAutolink
+)
+
 // '<' when tags or autolinks are allowed
 func leftAngle(p *parser, data []byte, offset int) int {
 	data = data[offset:]
-	altype := LinkTypeNotAutolink
-	end := tagLength(data, &altype)
+	altype, end := tagLength(data)
 	if size := p.inlineHTMLComment(data); size > 0 {
 		end = size
 	}
 	if end > 2 {
-		if altype != LinkTypeNotAutolink {
+		if altype != notAutolink {
 			var uLink bytes.Buffer
 			unescapeText(&uLink, data[1:end+1-2])
 			if uLink.Len() > 0 {
 				link := uLink.Bytes()
 				node := NewNode(Link)
 				node.Destination = link
-				if altype == LinkTypeEmail {
+				if altype == emailAutolink {
 					node.Destination = append([]byte("mailto:"), link...)
 				}
 				p.currBlock.appendChild(node)
@@ -924,17 +933,17 @@ func isSafeLink(link []byte) bool {
 }
 
 // return the length of the given tag, or 0 is it's not valid
-func tagLength(data []byte, autolink *LinkType) int {
+func tagLength(data []byte) (autolink autolinkType, end int) {
 	var i, j int
 
 	// a valid tag can't be shorter than 3 chars
 	if len(data) < 3 {
-		return 0
+		return notAutolink, 0
 	}
 
 	// begins with a '<' optionally followed by '/', followed by letter or number
 	if data[0] != '<' {
-		return 0
+		return notAutolink, 0
 	}
 	if data[1] == '/' {
 		i = 2
@@ -943,11 +952,11 @@ func tagLength(data []byte, autolink *LinkType) int {
 	}
 
 	if !isalnum(data[i]) {
-		return 0
+		return notAutolink, 0
 	}
 
 	// scheme test
-	*autolink = LinkTypeNotAutolink
+	autolink = notAutolink
 
 	// try to find the beginning of an URI
 	for i < len(data) && (isalnum(data[i]) || data[i] == '.' || data[i] == '+' || data[i] == '-') {
@@ -956,21 +965,20 @@ func tagLength(data []byte, autolink *LinkType) int {
 
 	if i > 1 && i < len(data) && data[i] == '@' {
 		if j = isMailtoAutoLink(data[i:]); j != 0 {
-			*autolink = LinkTypeEmail
-			return i + j
+			return emailAutolink, i + j
 		}
 	}
 
 	if i > 2 && i < len(data) && data[i] == ':' {
-		*autolink = LinkTypeNormal
+		autolink = normalAutolink
 		i++
 	}
 
 	// complete autolink test: no whitespace or ' or "
 	switch {
 	case i >= len(data):
-		*autolink = LinkTypeNotAutolink
-	case *autolink != 0:
+		autolink = notAutolink
+	case autolink != notAutolink:
 		j = i
 
 		for i < len(data) {
@@ -985,24 +993,20 @@ func tagLength(data []byte, autolink *LinkType) int {
 		}
 
 		if i >= len(data) {
-			return 0
+			return autolink, 0
 		}
 		if i > j && data[i] == '>' {
-			return i + 1
+			return autolink, i + 1
 		}
 
 		// one of the forbidden chars has been found
-		*autolink = LinkTypeNotAutolink
+		autolink = notAutolink
 	}
-
-	// look for something looking like a tag end
-	for i < len(data) && data[i] != '>' {
-		i++
+	i += bytes.IndexByte(data[i:], '>')
+	if i < 0 {
+		return autolink, 0
 	}
-	if i >= len(data) {
-		return 0
-	}
-	return i + 1
+	return autolink, i + 1
 }
 
 // look for the address part of a mail autolink and '>'

--- a/inline.go
+++ b/inline.go
@@ -266,13 +266,13 @@ func link(p *parser, data []byte, offset int) int {
 	// ![alt] == image
 	case offset >= 0 && data[offset] == '!':
 		t = linkImg
-		offset += 1
+		offset++
 	// ^[text] == inline footnote
 	// [^refId] == deferred footnote
 	case p.flags&Footnotes != 0:
 		if offset >= 0 && data[offset] == '^' {
 			t = linkInlineFootnote
-			offset += 1
+			offset++
 		} else if len(data)-1 > offset && data[offset+1] == '^' {
 			t = linkDeferredFootnote
 		}
@@ -590,7 +590,7 @@ func link(p *parser, data []byte, offset int) int {
 		linkNode.Title = title
 		p.currBlock.appendChild(linkNode)
 		linkNode.appendChild(text(data[1:txtE]))
-		i += 1
+		i++
 
 	case linkInlineFootnote, linkDeferredFootnote:
 		linkNode := NewNode(Link)
@@ -609,7 +609,7 @@ func link(p *parser, data []byte, offset int) int {
 	return i
 }
 
-func (p *parser) inlineHtmlComment(data []byte) int {
+func (p *parser) inlineHTMLComment(data []byte) int {
 	if len(data) < 5 {
 		return 0
 	}
@@ -643,7 +643,7 @@ func leftAngle(p *parser, data []byte, offset int) int {
 	data = data[offset:]
 	altype := LinkTypeNotAutolink
 	end := tagLength(data, &altype)
-	if size := p.inlineHtmlComment(data); size > 0 {
+	if size := p.inlineHTMLComment(data); size > 0 {
 		end = size
 	}
 	if end > 2 {
@@ -1026,9 +1026,8 @@ func isMailtoAutoLink(data []byte) int {
 		case '>':
 			if nb == 1 {
 				return i + 1
-			} else {
-				return 0
 			}
+			return 0
 		default:
 			return 0
 		}
@@ -1091,9 +1090,8 @@ func helperFindEmphChar(data []byte, c byte) int {
 			if data[i] != '[' && data[i] != '(' { // not a link
 				if tmpI > 0 {
 					return tmpI
-				} else {
-					continue
 				}
+				continue
 			}
 			cc := data[i]
 			i++
@@ -1218,17 +1216,15 @@ func helperTripleEmphasis(p *parser, data []byte, offset int, c byte) int {
 			length = helperEmphasis(p, origData[offset-2:], c)
 			if length == 0 {
 				return 0
-			} else {
-				return length - 2
 			}
+			return length - 2
 		default:
 			// single symbol found, hand over to emph2
 			length = helperDoubleEmphasis(p, origData[offset-1:], c)
 			if length == 0 {
 				return 0
-			} else {
-				return length - 1
 			}
+			return length - 1
 		}
 	}
 	return 0

--- a/inline_test.go
+++ b/inline_test.go
@@ -1168,3 +1168,11 @@ func TestSkipHTML(t *testing.T) {
 		"<p>text inline html more text</p>\n",
 	}, TestParams{HTMLFlags: SkipHTML})
 }
+
+func TestMathInline(t *testing.T) {
+	var tests = []string{
+		"$f(x) = x^2$\n",
+		"<p>\\(f(x) = x^2\\)</p>\n",
+	}
+	doTestsParam(t, tests, TestParams{Options: Options{Extensions: LaTeXMath}})
+}

--- a/inline_test.go
+++ b/inline_test.go
@@ -104,7 +104,7 @@ func TestReferenceOverride(t *testing.T) {
 			ReferenceOverride: func(reference string) (rv *Reference, overridden bool) {
 				switch reference {
 				case "ref1":
-					// just an overriden reference exists without definition
+					// just an overridden reference exists without definition
 					return &Reference{
 						Link:  "http://www.ref1.com/",
 						Title: "Reference 1"}, true

--- a/latex.go
+++ b/latex.go
@@ -311,7 +311,7 @@ func (r *Latex) DocumentHeader() {
 	r.w.WriteString("  pdfstartview=FitH,%\n")
 	r.w.WriteString("  breaklinks=true,%\n")
 	r.w.WriteString("  pdfauthor={Blackfriday Markdown Processor v")
-	r.w.WriteString(VERSION)
+	r.w.WriteString(Version)
 	r.w.WriteString("}}\n")
 	r.w.WriteString("\n")
 	r.w.WriteString("\\newcommand{\\HRule}{\\rule{\\linewidth}{0.5mm}}\n")

--- a/latex.go
+++ b/latex.go
@@ -15,7 +15,10 @@
 
 package blackfriday
 
-import "bytes"
+import (
+	"bytes"
+	"io"
+)
 
 // Latex is a type that implements the Renderer interface for LaTeX output.
 //
@@ -323,5 +326,11 @@ func (r *Latex) DocumentFooter() {
 }
 
 func (r *Latex) Render(ast *Node) []byte {
+	// TODO
 	return nil
+}
+
+func (r *Latex) RenderNode(w io.Writer, node *Node, entering bool) WalkStatus {
+	// TODO
+	return GoToNext
 }

--- a/latex.go
+++ b/latex.go
@@ -32,7 +32,7 @@ type Latex struct {
 //
 // flags is a set of LATEX_* options ORed together (currently no such options
 // are defined).
-func NewLatexRenderer(flags int) Renderer {
+func NewLatexRenderer(flags int) *Latex {
 	var writer bytes.Buffer
 	return &Latex{
 		w: writer,

--- a/latex.go
+++ b/latex.go
@@ -177,9 +177,9 @@ func (r *Latex) FootnoteItem(name, text []byte, flags ListType) {
 
 }
 
-func (r *Latex) AutoLink(link []byte, kind LinkType) {
+func (r *Latex) AutoLink(link []byte, kind autolinkType) {
 	r.w.WriteString("\\href{")
-	if kind == LinkTypeEmail {
+	if kind == emailAutolink {
 		r.w.WriteString("mailto:")
 	}
 	r.w.Write(link)

--- a/latex.go
+++ b/latex.go
@@ -21,7 +21,7 @@ import "bytes"
 //
 // Do not create this directly, instead use the NewLatexRenderer function.
 type Latex struct {
-	w HTMLWriter
+	w bytes.Buffer
 }
 
 // NewLatexRenderer creates and configures a Latex object, which
@@ -30,7 +30,7 @@ type Latex struct {
 // flags is a set of LATEX_* options ORed together (currently no such options
 // are defined).
 func NewLatexRenderer(flags int) Renderer {
-	var writer HTMLWriter
+	var writer bytes.Buffer
 	return &Latex{
 		w: writer,
 	}

--- a/markdown.go
+++ b/markdown.go
@@ -492,7 +492,7 @@ func (p *parser) parseRefsToAST() {
 		return
 	}
 	p.tip = p.doc
-	finalizeHtmlBlock(p.addBlock(HTMLBlock, []byte(`<div class="footnotes">`)))
+	finalizeHTMLBlock(p.addBlock(HTMLBlock, []byte(`<div class="footnotes">`)))
 	p.addBlock(HorizontalRule, nil)
 	block := p.addBlock(List, nil)
 	block.ListFlags = ListTypeOrdered
@@ -518,7 +518,7 @@ func (p *parser) parseRefsToAST() {
 	above := block.Parent
 	finalizeList(block)
 	p.tip = above
-	finalizeHtmlBlock(p.addBlock(HTMLBlock, []byte("</div>")))
+	finalizeHTMLBlock(p.addBlock(HTMLBlock, []byte("</div>")))
 	block.Walk(func(node *Node, entering bool) WalkStatus {
 		if node.Type == Paragraph || node.Type == Header {
 			p.currBlock = node

--- a/markdown.go
+++ b/markdown.go
@@ -21,6 +21,7 @@ package blackfriday
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"unicode/utf8"
 )
@@ -168,9 +169,10 @@ var blockTags = map[string]struct{}{
 // If the callback returns false, the rendering function should reset the
 // output buffer as though it had never been called.
 //
-// Currently Html and Latex implementations are provided
+// Currently HTML and Latex implementations are provided
 type Renderer interface {
 	Render(ast *Node) []byte
+	RenderNode(w io.Writer, node *Node, entering bool) WalkStatus
 }
 
 // Callback functions for inline parsing. One such function is defined

--- a/markdown.go
+++ b/markdown.go
@@ -60,6 +60,7 @@ const (
 	SmartypantsAngledQuotes                        // Enable angled double quotes (with Smartypants) for double quotes rendering
 	TOC                                            // Generate a table of contents
 	OmitContents                                   // Skip the main contents (for a standalone table of contents)
+	LaTeXMath                                      // LaTeX inline and display math surrounded by '$' or '$$'
 
 	CommonHTMLFlags HTMLFlags = UseXHTML
 
@@ -397,6 +398,10 @@ func Parse(input []byte, opts Options) *Node {
 
 	if extensions&Footnotes != 0 {
 		p.notes = make([]*reference, 0)
+	}
+
+	if extensions&LaTeXMath != 0 {
+		p.inlineCallback['$'] = math
 	}
 
 	first := firstPass(p, input)

--- a/markdown.go
+++ b/markdown.go
@@ -75,18 +75,6 @@ var DefaultOptions = Options{
 	Extensions: CommonExtensions,
 }
 
-// TODO: this should probably be unexported. Or moved to node.go
-type LinkType int
-
-// These are the possible flag values for the link renderer.
-// Only a single one of these values will be used; they are not ORed together.
-// These are mostly of interest if you are writing a new output format.
-const (
-	LinkTypeNotAutolink LinkType = iota
-	LinkTypeNormal
-	LinkTypeEmail
-)
-
 // ListType contains bitwise or'ed flags for list and list item objects.
 type ListType int
 

--- a/markdown.go
+++ b/markdown.go
@@ -324,12 +324,19 @@ func MarkdownBasic(input []byte) []byte {
 // Markdown with most useful extensions enabled, including:
 //
 // * Smartypants processing with smart fractions and LaTeX dashes
+//
 // * Intra-word emphasis suppression
+//
 // * Tables
+//
 // * Fenced code blocks
+//
 // * Autolinking
+//
 // * Strikethrough support
+//
 // * Strict header parsing
+//
 // * Custom Header IDs
 func MarkdownCommon(input []byte) []byte {
 	// set up the HTML renderer

--- a/markdown.go
+++ b/markdown.go
@@ -13,7 +13,7 @@
 //
 //
 
-// Blackfriday markdown processor.
+// Package blackfriday is a markdown processor.
 //
 // Translates plain text with simple formatting rules into HTML or LaTeX.
 package blackfriday
@@ -26,8 +26,11 @@ import (
 	"unicode/utf8"
 )
 
-const VERSION = "1.4"
+// Version string of the package.
+const Version = "2.0"
 
+// Extensions is a bitwise or'ed collection of enabled Blackfriday's
+// extensions.
 type Extensions int
 
 // These are the supported markdown parsing extensions.
@@ -58,7 +61,7 @@ const (
 	TOC                                            // Generate a table of contents
 	OmitContents                                   // Skip the main contents (for a standalone table of contents)
 
-	CommonHtmlFlags HTMLFlags = UseXHTML
+	CommonHTMLFlags HTMLFlags = UseXHTML
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeaders | HeaderIDs |
@@ -66,10 +69,13 @@ const (
 		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
 )
 
+// DefaultOptions is a convenience variable with all the options that are
+// enabled by default.
 var DefaultOptions = Options{
 	Extensions: CommonExtensions,
 }
 
+// TODO: this should probably be unexported. Or moved to node.go
 type LinkType int
 
 // These are the possible flag values for the link renderer.
@@ -81,6 +87,7 @@ const (
 	LinkTypeEmail
 )
 
+// ListType contains bitwise or'ed flags for list and list item objects.
 type ListType int
 
 // These are the possible flag values for the ListItem renderer.
@@ -96,6 +103,7 @@ const (
 	ListItemEndOfList
 )
 
+// CellAlignFlags holds a type of alignment in a table cell.
 type CellAlignFlags int
 
 // These are the possible flag values for the table cell renderer.
@@ -213,7 +221,7 @@ func (p *parser) getRef(refid string) (ref *reference, found bool) {
 			return &reference{
 				link:     []byte(r.Link),
 				title:    []byte(r.Title),
-				noteId:   0,
+				noteID:   0,
 				hasBlock: false,
 				text:     []byte(r.Text)}, true
 		}
@@ -312,29 +320,21 @@ func MarkdownBasic(input []byte) []byte {
 	return Markdown(input, renderer, Options{})
 }
 
-// Call Markdown with most useful extensions enabled
-// MarkdownCommon is a convenience function for simple rendering.
-// It processes markdown input with common extensions enabled, including:
+// MarkdownCommon is a convenience function for simple rendering. It calls
+// Markdown with most useful extensions enabled, including:
 //
 // * Smartypants processing with smart fractions and LaTeX dashes
-//
 // * Intra-word emphasis suppression
-//
 // * Tables
-//
 // * Fenced code blocks
-//
 // * Autolinking
-//
 // * Strikethrough support
-//
 // * Strict header parsing
-//
 // * Custom Header IDs
 func MarkdownCommon(input []byte) []byte {
 	// set up the HTML renderer
 	renderer := NewHTMLRenderer(HTMLRendererParameters{
-		Flags:      CommonHtmlFlags,
+		Flags:      CommonHTMLFlags,
 		Extensions: CommonExtensions,
 	})
 	return Markdown(input, renderer, DefaultOptions)
@@ -354,6 +354,10 @@ func Markdown(input []byte, renderer Renderer, options Options) []byte {
 	return renderer.Render(Parse(input, options))
 }
 
+// Parse is an entry point to the parsing part of Blackfriday. It takes an
+// input markdown document and produces a syntax tree for its contents. This
+// tree can then be rendered with a default or custom renderer, or
+// analyzed/transformed by the caller to whatever non-standard needs they have.
 func Parse(input []byte, opts Options) *Node {
 	extensions := opts.Extensions
 
@@ -592,7 +596,7 @@ func secondPass(p *parser, input []byte) {
 
 	if p.flags&Footnotes != 0 && len(p.notes) > 0 {
 		flags := ListItemBeginningOfList
-		for i := 0; i < len(p.notes); i += 1 {
+		for i := 0; i < len(p.notes); i++ {
 			ref := p.notes[i]
 			if ref.hasBlock {
 				flags |= ListItemContainsBlock
@@ -642,14 +646,14 @@ func secondPass(p *parser, input []byte) {
 type reference struct {
 	link     []byte
 	title    []byte
-	noteId   int // 0 if not a footnote ref
+	noteID   int // 0 if not a footnote ref
 	hasBlock bool
 	text     []byte
 }
 
 func (r *reference) String() string {
-	return fmt.Sprintf("{link: %q, title: %q, text: %q, noteId: %d, hasBlock: %v}",
-		r.link, r.title, r.text, r.noteId, r.hasBlock)
+	return fmt.Sprintf("{link: %q, title: %q, text: %q, noteID: %d, hasBlock: %v}",
+		r.link, r.title, r.text, r.noteID, r.hasBlock)
 }
 
 // Check whether or not data starts with a reference link.
@@ -667,7 +671,7 @@ func isReference(p *parser, data []byte, tabSize int) int {
 		i++
 	}
 
-	noteId := 0
+	noteID := 0
 
 	// id part: anything but a newline between brackets
 	if data[i] != '[' {
@@ -678,7 +682,7 @@ func isReference(p *parser, data []byte, tabSize int) int {
 		if i < len(data) && data[i] == '^' {
 			// we can set it to anything here because the proper noteIds will
 			// be assigned later during the second pass. It just has to be != 0
-			noteId = 1
+			noteID = 1
 			i++
 		}
 	}
@@ -721,7 +725,7 @@ func isReference(p *parser, data []byte, tabSize int) int {
 		hasBlock              bool
 	)
 
-	if p.flags&Footnotes != 0 && noteId != 0 {
+	if p.flags&Footnotes != 0 && noteID != 0 {
 		linkOffset, linkEnd, raw, hasBlock = scanFootnote(p, data, i, tabSize)
 		lineEnd = linkEnd
 	} else {
@@ -734,11 +738,11 @@ func isReference(p *parser, data []byte, tabSize int) int {
 	// a valid ref has been found
 
 	ref := &reference{
-		noteId:   noteId,
+		noteID:   noteID,
 		hasBlock: hasBlock,
 	}
 
-	if noteId > 0 {
+	if noteID > 0 {
 		// reusing the link field for the id since footnotes don't have links
 		ref.link = data[idOffset:idEnd]
 		// if footnote, it's not really a title, it's the contained text

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -1,0 +1,38 @@
+//
+// Blackfriday Markdown Processor
+// Available at http://github.com/russross/blackfriday
+//
+// Copyright © 2011 Russ Ross <russ@russross.com>.
+// Distributed under the Simplified BSD License.
+// See README.md for details.
+//
+
+//
+// Unit tests for full document parsing and rendering
+//
+
+package blackfriday
+
+import "testing"
+
+func TestDocument(t *testing.T) {
+	var tests = []string{
+		// Empty document.
+		"",
+		"",
+
+		" ",
+		"",
+
+		// This shouldn't panic.
+		// https://github.com/russross/blackfriday/issues/172
+		"[]:<",
+		"<p>[]:&lt;</p>\n",
+
+		// This shouldn't panic.
+		// https://github.com/russross/blackfriday/issues/173
+		"   [",
+		"<p>[</p>\n",
+	}
+	doTests(t, tests)
+}

--- a/node.go
+++ b/node.go
@@ -310,6 +310,10 @@ func (nw *NodeWalker) resumeAt(node *Node, entering bool) (*Node, bool) {
 	return nw.next()
 }
 
+func (ast *Node) String() string {
+	return dumpString(ast)
+}
+
 func dump(ast *Node) {
 	fmt.Println(dumpString(ast))
 }

--- a/node.go
+++ b/node.go
@@ -36,6 +36,8 @@ const (
 	TableHead
 	TableBody
 	TableRow
+	Math
+	MathBlock
 )
 
 var nodeTypeNames = []string{
@@ -63,6 +65,8 @@ var nodeTypeNames = []string{
 	TableHead:      "TableHead",
 	TableBody:      "TableBody",
 	TableRow:       "TableRow",
+	Math:           "Math",
+	MathBlock:      "MathBlock",
 }
 
 func (t NodeType) String() string {

--- a/node.go
+++ b/node.go
@@ -128,6 +128,16 @@ func NewNode(typ NodeType) *Node {
 	}
 }
 
+func (n *Node) String() string {
+	ellipsis := ""
+	snippet := n.Literal
+	if len(snippet) > 16 {
+		snippet = snippet[:16]
+		ellipsis = "..."
+	}
+	return fmt.Sprintf("%s: '%s%s'", n.Type, snippet, ellipsis)
+}
+
 func (n *Node) unlink() {
 	if n.Prev != nil {
 		n.Prev.Next = n.Next
@@ -308,10 +318,6 @@ func (nw *NodeWalker) resumeAt(node *Node, entering bool) (*Node, bool) {
 	nw.current = node
 	nw.entering = entering
 	return nw.next()
-}
-
-func (ast *Node) String() string {
-	return dumpString(ast)
 }
 
 func dump(ast *Node) {

--- a/ref_test.go
+++ b/ref_test.go
@@ -80,7 +80,7 @@ func TestReference_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 var benchResultAnchor string
 
 func BenchmarkReference(b *testing.B) {
-	params := TestParams{Options: Options{Extensions: NoExtensions}}
+	params := TestParams{Options: Options{Extensions: CommonExtensions}}
 	files := []string{
 		"Amps and angle encoding",
 		"Auto links",
@@ -115,6 +115,7 @@ func BenchmarkReference(b *testing.B) {
 		}
 		tests = append(tests, string(inputBytes))
 	}
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for _, test := range tests {
 			benchResultAnchor = runMarkdown(test, params)

--- a/ref_test.go
+++ b/ref_test.go
@@ -13,7 +13,11 @@
 
 package blackfriday
 
-import "testing"
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
 
 func TestReference(t *testing.T) {
 	files := []string{
@@ -69,4 +73,51 @@ func TestReference_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 		"Tidyness",
 	}
 	doTestsReference(t, files, NoEmptyLineBeforeBlock)
+}
+
+// benchResultAnchor is an anchor variable to store the result of a benchmarked
+// code so that compiler could never optimize away the call to runMarkdown()
+var benchResultAnchor string
+
+func BenchmarkReference(b *testing.B) {
+	params := TestParams{Options: Options{Extensions: NoExtensions}}
+	files := []string{
+		"Amps and angle encoding",
+		"Auto links",
+		"Backslash escapes",
+		"Blockquotes with code blocks",
+		"Code Blocks",
+		"Code Spans",
+		"Hard-wrapped paragraphs with list-like lines",
+		"Horizontal rules",
+		"Inline HTML (Advanced)",
+		"Inline HTML (Simple)",
+		"Inline HTML comments",
+		"Links, inline style",
+		"Links, reference style",
+		"Links, shortcut references",
+		"Literal quotes in titles",
+		"Markdown Documentation - Basics",
+		"Markdown Documentation - Syntax",
+		"Nested blockquotes",
+		"Ordered and unordered lists",
+		"Strong and em together",
+		"Tabs",
+		"Tidyness",
+	}
+	var tests []string
+	for _, basename := range files {
+		filename := filepath.Join("testdata", basename+".text")
+		inputBytes, err := ioutil.ReadFile(filename)
+		if err != nil {
+			b.Errorf("Couldn't open '%s', error: %v\n", filename, err)
+			continue
+		}
+		tests = append(tests, string(inputBytes))
+	}
+	for n := 0; n < b.N; n++ {
+		for _, test := range tests {
+			benchResultAnchor = runMarkdown(test, params)
+		}
+	}
 }

--- a/smartypants.go
+++ b/smartypants.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 )
 
+// SPRenderer is a struct containing state of a Smartypants renderer.
 type SPRenderer struct {
 	inSingleQuote bool
 	inDoubleQuote bool
@@ -366,6 +367,7 @@ func (smrt *SPRenderer) smartLeftAngle(out *bytes.Buffer, previousChar byte, tex
 
 type smartCallback func(out *bytes.Buffer, previousChar byte, text []byte) int
 
+// NewSmartypantsRenderer constructs a Smartypants renderer object.
 func NewSmartypantsRenderer(flags Extensions) *SPRenderer {
 	var r SPRenderer
 	if flags&SmartypantsAngledQuotes == 0 {
@@ -398,13 +400,14 @@ func NewSmartypantsRenderer(flags Extensions) *SPRenderer {
 	return &r
 }
 
-func (sr *SPRenderer) Process(text []byte) []byte {
+// Process is the entry point of the Smartypants renderer.
+func (smrt *SPRenderer) Process(text []byte) []byte {
 	var buff bytes.Buffer
 	// first do normal entity escaping
 	text = esc(text)
 	mark := 0
 	for i := 0; i < len(text); i++ {
-		if action := sr.callbacks[text[i]]; action != nil {
+		if action := smrt.callbacks[text[i]]; action != nil {
 			if i > mark {
 				buff.Write(text[mark:i])
 			}

--- a/smartypants.go
+++ b/smartypants.go
@@ -401,7 +401,7 @@ func NewSmartypantsRenderer(flags Extensions) *SPRenderer {
 func (sr *SPRenderer) Process(text []byte) []byte {
 	var buff bytes.Buffer
 	// first do normal entity escaping
-	text = attrEscape(text)
+	text = esc(text)
 	mark := 0
 	for i := 0; i < len(text); i++ {
 		if action := sr.callbacks[text[i]]; action != nil {

--- a/smartypants.go
+++ b/smartypants.go
@@ -109,7 +109,7 @@ func smartQuoteHelper(out *bytes.Buffer, previousChar byte, nextChar byte, quote
 	return true
 }
 
-func (smrt *SPRenderer) smartSingleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartSingleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if len(text) >= 2 {
 		t1 := tolower(text[1])
 
@@ -118,7 +118,7 @@ func (smrt *SPRenderer) smartSingleQuote(out *bytes.Buffer, previousChar byte, t
 			if len(text) >= 3 {
 				nextChar = text[2]
 			}
-			if smartQuoteHelper(out, previousChar, nextChar, 'd', &smrt.inDoubleQuote) {
+			if smartQuoteHelper(out, previousChar, nextChar, 'd', &r.inDoubleQuote) {
 				return 1
 			}
 		}
@@ -143,7 +143,7 @@ func (smrt *SPRenderer) smartSingleQuote(out *bytes.Buffer, previousChar byte, t
 	if len(text) > 1 {
 		nextChar = text[1]
 	}
-	if smartQuoteHelper(out, previousChar, nextChar, 's', &smrt.inSingleQuote) {
+	if smartQuoteHelper(out, previousChar, nextChar, 's', &r.inSingleQuote) {
 		return 0
 	}
 
@@ -151,7 +151,7 @@ func (smrt *SPRenderer) smartSingleQuote(out *bytes.Buffer, previousChar byte, t
 	return 0
 }
 
-func (smrt *SPRenderer) smartParens(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartParens(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if len(text) >= 3 {
 		t1 := tolower(text[1])
 		t2 := tolower(text[2])
@@ -176,7 +176,7 @@ func (smrt *SPRenderer) smartParens(out *bytes.Buffer, previousChar byte, text [
 	return 0
 }
 
-func (smrt *SPRenderer) smartDash(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartDash(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if len(text) >= 2 {
 		if text[1] == '-' {
 			out.WriteString("&mdash;")
@@ -193,7 +193,7 @@ func (smrt *SPRenderer) smartDash(out *bytes.Buffer, previousChar byte, text []b
 	return 0
 }
 
-func (smrt *SPRenderer) smartDashLatex(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartDashLatex(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if len(text) >= 3 && text[1] == '-' && text[2] == '-' {
 		out.WriteString("&mdash;")
 		return 2
@@ -207,13 +207,13 @@ func (smrt *SPRenderer) smartDashLatex(out *bytes.Buffer, previousChar byte, tex
 	return 0
 }
 
-func (smrt *SPRenderer) smartAmpVariant(out *bytes.Buffer, previousChar byte, text []byte, quote byte) int {
+func (r *SPRenderer) smartAmpVariant(out *bytes.Buffer, previousChar byte, text []byte, quote byte) int {
 	if bytes.HasPrefix(text, []byte("&quot;")) {
 		nextChar := byte(0)
 		if len(text) >= 7 {
 			nextChar = text[6]
 		}
-		if smartQuoteHelper(out, previousChar, nextChar, quote, &smrt.inDoubleQuote) {
+		if smartQuoteHelper(out, previousChar, nextChar, quote, &r.inDoubleQuote) {
 			return 5
 		}
 	}
@@ -226,15 +226,15 @@ func (smrt *SPRenderer) smartAmpVariant(out *bytes.Buffer, previousChar byte, te
 	return 0
 }
 
-func (smrt *SPRenderer) smartAmp(out *bytes.Buffer, previousChar byte, text []byte) int {
-	return smrt.smartAmpVariant(out, previousChar, text, 'd')
+func (r *SPRenderer) smartAmp(out *bytes.Buffer, previousChar byte, text []byte) int {
+	return r.smartAmpVariant(out, previousChar, text, 'd')
 }
 
-func (smrt *SPRenderer) smartAmpAngledQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
-	return smrt.smartAmpVariant(out, previousChar, text, 'a')
+func (r *SPRenderer) smartAmpAngledQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
+	return r.smartAmpVariant(out, previousChar, text, 'a')
 }
 
-func (smrt *SPRenderer) smartPeriod(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartPeriod(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if len(text) >= 3 && text[1] == '.' && text[2] == '.' {
 		out.WriteString("&hellip;")
 		return 2
@@ -249,13 +249,13 @@ func (smrt *SPRenderer) smartPeriod(out *bytes.Buffer, previousChar byte, text [
 	return 0
 }
 
-func (smrt *SPRenderer) smartBacktick(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartBacktick(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if len(text) >= 2 && text[1] == '`' {
 		nextChar := byte(0)
 		if len(text) >= 3 {
 			nextChar = text[2]
 		}
-		if smartQuoteHelper(out, previousChar, nextChar, 'd', &smrt.inDoubleQuote) {
+		if smartQuoteHelper(out, previousChar, nextChar, 'd', &r.inDoubleQuote) {
 			return 1
 		}
 	}
@@ -264,7 +264,7 @@ func (smrt *SPRenderer) smartBacktick(out *bytes.Buffer, previousChar byte, text
 	return 0
 }
 
-func (smrt *SPRenderer) smartNumberGeneric(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartNumberGeneric(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if wordBoundary(previousChar) && previousChar != '/' && len(text) >= 3 {
 		// is it of the form digits/digits(word boundary)?, i.e., \d+/\d+\b
 		// note: check for regular slash (/) or fraction slash (⁄, 0x2044, or 0xe2 81 84 in utf-8)
@@ -306,7 +306,7 @@ func (smrt *SPRenderer) smartNumberGeneric(out *bytes.Buffer, previousChar byte,
 	return 0
 }
 
-func (smrt *SPRenderer) smartNumber(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartNumber(out *bytes.Buffer, previousChar byte, text []byte) int {
 	if wordBoundary(previousChar) && previousChar != '/' && len(text) >= 3 {
 		if text[0] == '1' && text[1] == '/' && text[2] == '2' {
 			if len(text) < 4 || wordBoundary(text[3]) && text[3] != '/' {
@@ -334,27 +334,27 @@ func (smrt *SPRenderer) smartNumber(out *bytes.Buffer, previousChar byte, text [
 	return 0
 }
 
-func (smrt *SPRenderer) smartDoubleQuoteVariant(out *bytes.Buffer, previousChar byte, text []byte, quote byte) int {
+func (r *SPRenderer) smartDoubleQuoteVariant(out *bytes.Buffer, previousChar byte, text []byte, quote byte) int {
 	nextChar := byte(0)
 	if len(text) > 1 {
 		nextChar = text[1]
 	}
-	if !smartQuoteHelper(out, previousChar, nextChar, quote, &smrt.inDoubleQuote) {
+	if !smartQuoteHelper(out, previousChar, nextChar, quote, &r.inDoubleQuote) {
 		out.WriteString("&quot;")
 	}
 
 	return 0
 }
 
-func (smrt *SPRenderer) smartDoubleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
-	return smrt.smartDoubleQuoteVariant(out, previousChar, text, 'd')
+func (r *SPRenderer) smartDoubleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
+	return r.smartDoubleQuoteVariant(out, previousChar, text, 'd')
 }
 
-func (smrt *SPRenderer) smartAngledDoubleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
-	return smrt.smartDoubleQuoteVariant(out, previousChar, text, 'a')
+func (r *SPRenderer) smartAngledDoubleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
+	return r.smartDoubleQuoteVariant(out, previousChar, text, 'a')
 }
 
-func (smrt *SPRenderer) smartLeftAngle(out *bytes.Buffer, previousChar byte, text []byte) int {
+func (r *SPRenderer) smartLeftAngle(out *bytes.Buffer, previousChar byte, text []byte) int {
 	i := 0
 
 	for i < len(text) && text[i] != '>' {
@@ -401,13 +401,13 @@ func NewSmartypantsRenderer(flags Extensions) *SPRenderer {
 }
 
 // Process is the entry point of the Smartypants renderer.
-func (smrt *SPRenderer) Process(text []byte) []byte {
+func (r *SPRenderer) Process(text []byte) []byte {
 	var buff bytes.Buffer
 	// first do normal entity escaping
 	text = esc(text)
 	mark := 0
 	for i := 0; i < len(text); i++ {
-		if action := smrt.callbacks[text[i]]; action != nil {
+		if action := r.callbacks[text[i]]; action != nil {
 			if i > mark {
 				buff.Write(text[mark:i])
 			}


### PR DESCRIPTION
It enables direct math support in LaTeX, as well as HTML with MathJax.

I believe this feature to be a popular demand. See #256 and #220.

This is a request for comments, as I am quite new to Blackfriday.
I haven't written many tests yet, I'm waiting for your comments.

The main point of contention would be the math delimiter, being '$' and '$$' at the moment. This obviously creates a conflict with a regular use of the dollar signe. Both MathJax and LaTeX use '(' and '['. I am not sure how we can use those in Markdown because of the conflict with the 'escape' rules.
