### PR TITLE
v2: Fix TOC generation

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -1526,6 +1526,71 @@ func TestTOC(t *testing.T) {
 <h1 id="toc_2">Title2</h1>
 `,
 
+		"## Subtitle\n\n# Title",
+		`<nav>
+
+<ul>
+<li>
+<ul>
+<li><a href="#toc_0">Subtitle</a></li>
+</ul></li>
+
+<li><a href="#toc_1">Title</a></li>
+</ul>
+
+</nav>
+
+<h2 id="toc_0">Subtitle</h2>
+
+<h1 id="toc_1">Title</h1>
+`,
+
+		"# Title 1\n\n## Subtitle 1\n\n### Subsubtitle 1\n\n# Title 2\n\n### Subsubtitle 2",
+		`<nav>
+
+<ul>
+<li><a href="#toc_0">Title 1</a>
+<ul>
+<li><a href="#toc_1">Subtitle 1</a>
+<ul>
+<li><a href="#toc_2">Subsubtitle 1</a></li>
+</ul></li>
+</ul></li>
+
+<li><a href="#toc_3">Title 2</a>
+<ul>
+<li>
+<ul>
+<li><a href="#toc_4">Subsubtitle 2</a></li>
+</ul></li>
+</ul></li>
+</ul>
+
+</nav>
+
+<h1 id="toc_0">Title 1</h1>
+
+<h2 id="toc_1">Subtitle 1</h2>
+
+<h3 id="toc_2">Subsubtitle 1</h3>
+
+<h1 id="toc_3">Title 2</h1>
+
+<h3 id="toc_4">Subsubtitle 2</h3>
+`,
+
+		"# Title with `code`",
+		`<nav>
+
+<ul>
+<li><a href="#toc_0">Title with <code>code</code></a></li>
+</ul>
+
+</nav>
+
+<h1 id="toc_0">Title with <code>code</code></h1>
+`,
+
 		// Trigger empty TOC
 		"#",
 		"",

--- a/node.go
+++ b/node.go
@@ -171,6 +171,43 @@ func (n *Node) insertBefore(sibling *Node) {
 	}
 }
 
+// deepCopy returns a copy of n and all its children.
+// The resulting root node is not linked, i.e. Parent, Prev and Next fields are
+// set to nil.
+func (n *Node) deepCopy() *Node {
+	new := new(Node)
+	*new = *n
+	if n.FirstChild != nil {
+		new.FirstChild = n.FirstChild.deepCopy()
+		new.FirstChild.Parent = new
+		new.FirstChild.Prev = nil
+		new.FirstChild.Next = nil
+		new.LastChild = new.FirstChild
+		new.LastChild.Parent = new
+		new.LastChild.Prev = nil
+		new.LastChild.Next = nil
+		for c, newc := n.FirstChild, new.FirstChild; c.Next != nil; c, newc = c.Next, newc.Next {
+			newc.Next = c.Next.deepCopy()
+			newc.Next.Parent = new
+			newc.Next.Prev = newc
+			new.LastChild = newc.Next
+			new.LastChild.Parent = new
+			new.LastChild.Prev = newc
+		}
+	}
+
+	new.Parent = nil
+	new.Prev = nil
+	new.Next = nil
+
+	new.Literal = make([]byte, len(n.Literal))
+	copy(new.Literal, n.Literal)
+
+	new.content = make([]byte, len(n.content))
+	copy(new.content, n.content)
+	return new
+}
+
 func (n *Node) isContainer() bool {
 	switch n.Type {
 	case Document:


### PR DESCRIPTION
Track levels properly.
Support headers with multiple/nested children.
Can jump for more than 1 level at once.

This path highlights a "weakness" of the current implementation: if the renderer wants to use "all the text of the node and its children", it needs some work... I've writtent a deep copy function for nodes that could help a lot here, so we should consider exporting it.

Any thoughts on this?