### PR TITLE
Make newline mandatory for opening fence line.

### DIFF
--- a/block.go
+++ b/block.go
@@ -664,7 +664,7 @@ func isFenceLine(data []byte, syntax *string, oldmarker string, newlineOptional 
 // If doRender is true, a final newline is mandatory to recognize the fenced code block.
 func (p *parser) fencedCodeBlock(out *bytes.Buffer, data []byte, doRender bool) int {
 	var syntax string
-	beg, marker := isFenceLine(data, &syntax, "", true)
+	beg, marker := isFenceLine(data, &syntax, "", false)
 	if beg == 0 || beg >= len(data) {
 		return 0
 	}

--- a/block_test.go
+++ b/block_test.go
@@ -1662,6 +1662,12 @@ func TestIsFenceLine(t *testing.T) {
 			wantMarker: "```",
 		},
 		{
+			data:            []byte("```\nstuff here\n"),
+			syntaxRequested: true,
+			wantEnd:         4,
+			wantMarker:      "```",
+		},
+		{
 			data:    []byte("stuff here\n```\n"),
 			wantEnd: 0,
 		},


### PR DESCRIPTION
This was an unintended typo/mistake in #280.

This is stricter, and it's fine. The opening fence line will always need to have a newline.

Add another test for `isFenceLine`.