### PR TITLE
Unpublish and rename LinkType constants

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -638,13 +638,12 @@ func stripMailto(link []byte) []byte {
 	}
 }
 
-// autoLinkType specifies a kind of autolink that gets detected.
-type autoLinkType int
+// autolinkType specifies a kind of autolink that gets detected.
+type autolinkType int
 
 // These are the possible flag values for the autolink renderer.
-// Only a single one of these values will be used; they are not ORed together.
 const (
-	notAutolink autoLinkType = iota
+	notAutolink autolinkType = iota
 	normalAutolink
 	emailAutolink
 )
@@ -934,7 +933,7 @@ func isSafeLink(link []byte) bool {
 }
 
 // return the length of the given tag, or 0 is it's not valid
-func tagLength(data []byte) (autolink autoLinkType, end int) {
+func tagLength(data []byte) (autolink autolinkType, end int) {
 	var i, j int
 
 	// a valid tag can't be shorter than 3 chars

--- a/latex.go
+++ b/latex.go
@@ -177,9 +177,9 @@ func (r *Latex) FootnoteItem(name, text []byte, flags ListType) {
 
 }
 
-func (r *Latex) AutoLink(link []byte, kind LinkType) {
+func (r *Latex) AutoLink(link []byte, kind autoLinkType) {
 	r.w.WriteString("\\href{")
-	if kind == LinkTypeEmail {
+	if kind == emailAutolink {
 		r.w.WriteString("mailto:")
 	}
 	r.w.Write(link)

--- a/latex.go
+++ b/latex.go
@@ -177,7 +177,7 @@ func (r *Latex) FootnoteItem(name, text []byte, flags ListType) {
 
 }
 
-func (r *Latex) AutoLink(link []byte, kind autoLinkType) {
+func (r *Latex) AutoLink(link []byte, kind autolinkType) {
 	r.w.WriteString("\\href{")
 	if kind == emailAutolink {
 		r.w.WriteString("mailto:")

--- a/markdown.go
+++ b/markdown.go
@@ -75,18 +75,6 @@ var DefaultOptions = Options{
 	Extensions: CommonExtensions,
 }
 
-// TODO: this should probably be unexported. Or moved to node.go
-type LinkType int
-
-// These are the possible flag values for the link renderer.
-// Only a single one of these values will be used; they are not ORed together.
-// These are mostly of interest if you are writing a new output format.
-const (
-	LinkTypeNotAutolink LinkType = iota
-	LinkTypeNormal
-	LinkTypeEmail
-)
-
 // ListType contains bitwise or'ed flags for list and list item objects.
 type ListType int
 


### PR DESCRIPTION
The constants are only used in the parsing phase, they are not recorded
in the AST directly, so make them private. Improve their names along the
way. Fix tagLength to return two values instead of taking an output
parameter.