### PR TITLE
Repeat a run of reference tests under benchmark

### DIFF
--- a/ref_test.go
+++ b/ref_test.go
@@ -80,7 +80,7 @@ func TestReference_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 var benchResultAnchor string
 
 func BenchmarkReference(b *testing.B) {
-	params := TestParams{Options: Options{Extensions: NoExtensions}}
+	params := TestParams{Options: Options{Extensions: CommonExtensions}}
 	files := []string{
 		"Amps and angle encoding",
 		"Auto links",
@@ -115,6 +115,7 @@ func BenchmarkReference(b *testing.B) {
 		}
 		tests = append(tests, string(inputBytes))
 	}
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for _, test := range tests {
 			benchResultAnchor = runMarkdown(test, params)

--- a/ref_test.go
+++ b/ref_test.go
@@ -13,7 +13,11 @@
 
 package blackfriday
 
-import "testing"
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
 
 func TestReference(t *testing.T) {
 	files := []string{
@@ -69,4 +73,51 @@ func TestReference_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 		"Tidyness",
 	}
 	doTestsReference(t, files, NoEmptyLineBeforeBlock)
+}
+
+// benchResultAnchor is an anchor variable to store the result of a benchmarked
+// code so that compiler could never optimize away the call to runMarkdown()
+var benchResultAnchor string
+
+func BenchmarkReference(b *testing.B) {
+	params := TestParams{Options: Options{Extensions: NoExtensions}}
+	files := []string{
+		"Amps and angle encoding",
+		"Auto links",
+		"Backslash escapes",
+		"Blockquotes with code blocks",
+		"Code Blocks",
+		"Code Spans",
+		"Hard-wrapped paragraphs with list-like lines",
+		"Horizontal rules",
+		"Inline HTML (Advanced)",
+		"Inline HTML (Simple)",
+		"Inline HTML comments",
+		"Links, inline style",
+		"Links, reference style",
+		"Links, shortcut references",
+		"Literal quotes in titles",
+		"Markdown Documentation - Basics",
+		"Markdown Documentation - Syntax",
+		"Nested blockquotes",
+		"Ordered and unordered lists",
+		"Strong and em together",
+		"Tabs",
+		"Tidyness",
+	}
+	var tests []string
+	for _, basename := range files {
+		filename := filepath.Join("testdata", basename+".text")
+		inputBytes, err := ioutil.ReadFile(filename)
+		if err != nil {
+			b.Errorf("Couldn't open '%s', error: %v\n", filename, err)
+			continue
+		}
+		tests = append(tests, string(inputBytes))
+	}
+	for n := 0; n < b.N; n++ {
+		for _, test := range tests {
+			benchResultAnchor = runMarkdown(test, params)
+		}
+	}
 }


### PR DESCRIPTION
Currently v2 is ~2.7x slower than v1. I have a bunch of optimizations of varying stages of hackiness on my box that (currently) bring it down to ~1.3x slower. I'm planning to push those changes to a separate optimizations branch bit by bit. So I want to get this benchmark landed on v2 before I branch off.