### PR TITLE
Add Math extension

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -1656,3 +1656,20 @@ func TestIsFenceLine(t *testing.T) {
 		}
 	}
 }
+
+func TestMathBlock(t *testing.T) {
+	var tests = []string{
+		"$$f(x) = x^2$$\n",
+		"\\[f(x) = x^2\\]\n",
+
+		"$$x<y$$\n",
+		"\\[x&lt;y\\]\n",
+
+		"$$x^2\n",
+		"<p>$$x^2</p>\n",
+
+		"x^2$$\n",
+		"<p>x^2$$</p>\n",
+	}
+	doTestsBlock(t, tests, LaTeXMath)
+}

--- a/html.go
+++ b/html.go
@@ -698,6 +698,16 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 			r.out(w, tag("/tr", nil, false))
 			r.cr(w)
 		}
+	case Math:
+		r.out(w, []byte("\\("))
+		r.out(w, escCode(node.Literal))
+		r.out(w, []byte("\\)"))
+	case MathBlock:
+		r.out(w, []byte("\\["))
+		r.out(w, escCode(node.Literal))
+		r.out(w, []byte("\\]"))
+		r.cr(w)
+
 	default:
 		panic("Unknown node type " + node.Type.String())
 	}

--- a/inline.go
+++ b/inline.go
@@ -1234,6 +1234,35 @@ func helperTripleEmphasis(p *parser, data []byte, offset int, c byte) int {
 	return 0
 }
 
+// LaTeX math surrounded by '$' or '$$'
+func math(p *parser, data []byte, offset int) int {
+	data = data[offset:]
+
+	// inline math
+	if len(data) > 2 && data[1] != '$' {
+		// find the next '$'
+		end := 1
+		for end < len(data) && data[end] != '$' {
+			end++
+		}
+
+		// no matching delimiter?
+		if end == len(data) {
+			return 0
+		}
+
+		// render the inline math
+		if end != 0 {
+			math := NewNode(Math)
+			math.Literal = data[1:end]
+			p.currBlock.appendChild(math)
+		}
+		return end + 1
+	}
+
+	return 0
+}
+
 func text(s []byte) *Node {
 	node := NewNode(Text)
 	node.Literal = s

--- a/inline_test.go
+++ b/inline_test.go
@@ -1168,3 +1168,11 @@ func TestSkipHTML(t *testing.T) {
 		"<p>text inline html more text</p>\n",
 	}, TestParams{HTMLFlags: SkipHTML})
 }
+
+func TestMathInline(t *testing.T) {
+	var tests = []string{
+		"$f(x) = x^2$\n",
+		"<p>\\(f(x) = x^2\\)</p>\n",
+	}
+	doTestsParam(t, tests, TestParams{Options: Options{Extensions: LaTeXMath}})
+}

--- a/markdown.go
+++ b/markdown.go
@@ -60,6 +60,7 @@ const (
 	SmartypantsAngledQuotes                        // Enable angled double quotes (with Smartypants) for double quotes rendering
 	TOC                                            // Generate a table of contents
 	OmitContents                                   // Skip the main contents (for a standalone table of contents)
+	LaTeXMath                                      // LaTeX inline and display math surrounded by '$' or '$$'
 
 	CommonHTMLFlags HTMLFlags = UseXHTML
 
@@ -397,6 +398,10 @@ func Parse(input []byte, opts Options) *Node {
 
 	if extensions&Footnotes != 0 {
 		p.notes = make([]*reference, 0)
+	}
+
+	if extensions&LaTeXMath != 0 {
+		p.inlineCallback['$'] = math
 	}
 
 	first := firstPass(p, input)

--- a/node.go
+++ b/node.go
@@ -36,6 +36,8 @@ const (
 	TableHead
 	TableBody
 	TableRow
+	Math
+	MathBlock
 )
 
 var nodeTypeNames = []string{
@@ -63,6 +65,8 @@ var nodeTypeNames = []string{
 	TableHead:      "TableHead",
 	TableBody:      "TableBody",
 	TableRow:       "TableRow",
+	Math:           "Math",
+	MathBlock:      "MathBlock",
 }
 
 func (t NodeType) String() string {


### PR DESCRIPTION
It enables direct math support in LaTeX, as well as HTML with MathJax.

I believe this feature to be a popular demand. See #256 and #220.

This is a request for comments, as I am quite new to Blackfriday.
I haven't written many tests yet, I'm waiting for your comments.

The main point of contention would be the math delimiter, being '$' and '$$' at the moment. This obviously creates a conflict with a regular use of the dollar signe. Both MathJax and LaTeX use '(' and '['. I am not sure how we can use those in Markdown because of the conflict with the 'escape' rules.
