### PR TITLE
v2: Only split when inline callbacks consume some bytes

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -192,10 +192,8 @@ func maybeLineBreak(p *parser, data []byte, offset int) (int, *Node) {
 // newline without two spaces works when HardLineBreak is enabled
 func lineBreak(p *parser, data []byte, offset int) (int, *Node) {
 	if p.flags&HardLineBreak != 0 {
-		// log.Print("LINEBREAK")
 		return 1, NewNode(Hardbreak)
 	}
-	// log.Print("NOLINEBREAK")
 	return 0, nil
 }
 


### PR DESCRIPTION
The former hacks around maybeLineBreak and Smartypants are no longer
needed.
The algorithm has been streamlined: shorter, simpler, faster.
The 'currBlock' field of the parser is gone.

Bonus: A rough perf increase of 6-8%!