### PR TITLE
v2: move footnotes to html

### DIFF
--- a/block.go
+++ b/block.go
@@ -1380,13 +1380,24 @@ func (p *parser) paragraph(data []byte) int {
 	// line: index of 1st char of current line
 	// i: index of cursor/end of current line
 	var prev, line, i int
-
+	tabSize := TabSizeDefault
+	if p.flags&TabSizeEight != 0 {
+		tabSize = TabSizeDouble
+	}
 	// keep going until we find something to mark the end of the paragraph
 	for i < len(data) {
 		// mark the beginning of the current line
 		prev = line
 		current := data[i:]
 		line = i
+
+		// did we find a reference or a footnote? If so, end a paragraph
+		// preceding it and report that we have consumed up to the end of that
+		// reference:
+		if refEnd := isReference(p, current, tabSize); refEnd > 0 {
+			p.renderParagraph(data[:i])
+			return i + refEnd
+		}
 
 		// did we find a blank line marking the end of the paragraph?
 		if n := p.isEmpty(current); n > 0 {

--- a/html.go
+++ b/html.go
@@ -589,10 +589,11 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 			tagName = "dl"
 		}
 		if entering {
-			// var start = node.listStart;
-			// if (start !== null && start !== 1) {
-			//     attrs.push(['start', start.toString()]);
-			// }
+			if node.IsFootnotesList {
+				r.out(w, []byte("\n<div class=\"footnotes\">\n\n"))
+				r.out(w, tag("hr", attrs, r.Flags&UseXHTML != 0))
+				r.cr(w)
+			}
 			r.cr(w)
 			if node.Parent.Type == Item && node.Parent.Parent.Tight {
 				r.cr(w)
@@ -610,6 +611,9 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 			}
 			if node.Parent.Type == Document || node.Parent.Type == BlockQuote {
 				r.cr(w)
+			}
+			if node.IsFootnotesList {
+				r.out(w, []byte("\n</div>\n"))
 			}
 		}
 	case Item:

--- a/inline_test.go
+++ b/inline_test.go
@@ -922,6 +922,12 @@ what happens here
 
 </div>
 `,
+
+	`This text does not reference a footnote.
+
+[^footnote]: But it has a footnote! And it gets omitted.
+`,
+	"<p>This text does not reference a footnote.</p>\n",
 }
 
 func TestFootnotes(t *testing.T) {

--- a/markdown.go
+++ b/markdown.go
@@ -416,9 +416,8 @@ func (p *parser) parseRefsToAST() {
 		return
 	}
 	p.tip = p.doc
-	finalizeHTMLBlock(p.addBlock(HTMLBlock, []byte(`<div class="footnotes">`)))
-	p.addBlock(HorizontalRule, nil)
 	block := p.addBlock(List, nil)
+	block.IsFootnotesList = true
 	block.ListFlags = ListTypeOrdered
 	flags := ListItemBeginningOfList
 	// Note: this loop is intentionally explicit, not range-form. This is
@@ -441,7 +440,6 @@ func (p *parser) parseRefsToAST() {
 	above := block.Parent
 	finalizeList(block)
 	p.tip = above
-	finalizeHTMLBlock(p.addBlock(HTMLBlock, []byte("</div>")))
 	block.Walk(func(node *Node, entering bool) WalkStatus {
 		if node.Type == Paragraph || node.Type == Header {
 			p.inline(node, node.content)

--- a/markdown.go
+++ b/markdown.go
@@ -555,8 +555,8 @@ func firstPass(p *parser, input []byte) []byte {
 //         title: "tooltip title",
 //     }
 //
-// Alternatively, reference can contain an information about a footnote.
-// Consider this markdown:
+// Alternatively, reference can contain information about a footnote. Consider
+// this markdown:
 //
 //     Text needing a footnote.[^a]
 //

--- a/markdown.go
+++ b/markdown.go
@@ -535,13 +535,50 @@ func firstPass(p *parser, input []byte) []byte {
 //
 // are not yet supported.
 
-// References are parsed and stored in this struct.
+// reference holds all information necessary for a reference-style links or
+// footnotes.
+//
+// Consider this markdown with reference-style links:
+//
+//     [link][ref]
+//
+//     [ref]: /url/ "tooltip title"
+//
+// It will be ultimately converted to this HTML:
+//
+//     <p><a href=\"/url/\" title=\"title\">link</a></p>
+//
+// And a reference structure will be populated as follows:
+//
+//     p.refs["ref"] = &reference{
+//         link: "/url/",
+//         title: "tooltip title",
+//     }
+//
+// Alternatively, reference can contain an information about a footnote.
+// Consider this markdown:
+//
+//     Text needing a footnote.[^a]
+//
+//     [^a]: This is the note
+//
+// A reference structure will be populated as follows:
+//
+//     p.refs["a"] = &reference{
+//         link: "a",
+//         title: "This is the note",
+//         noteID: <some positive int>,
+//     }
+//
+// TODO: As you can see, it begs for splitting into two dedicated structures
+// for refs and for footnotes.
 type reference struct {
 	link     []byte
 	title    []byte
 	noteID   int // 0 if not a footnote ref
 	hasBlock bool
-	text     []byte
+
+	text []byte // only gets populated by refOverride feature with Reference.Text
 }
 
 func (r *reference) String() string {

--- a/markdown.go
+++ b/markdown.go
@@ -394,7 +394,7 @@ func Parse(input []byte, opts Options) *Node {
 		p.notes = make([]*reference, 0)
 	}
 
-	p.block(firstPass(p, input))
+	p.block(preprocess(p, input))
 	// Walk the tree and finish up some of unfinished blocks
 	for p.tip != nil {
 		p.finalize(p.tip)
@@ -449,11 +449,11 @@ func (p *parser) parseRefsToAST() {
 	})
 }
 
-// first pass:
+// preprocess does a preparatory first pass over the input:
 // - normalize newlines
 // - expand tabs (outside of fenced code blocks)
 // - copy everything else
-func firstPass(p *parser, input []byte) []byte {
+func preprocess(p *parser, input []byte) []byte {
 	var out bytes.Buffer
 	tabSize := TabSizeDefault
 	if p.flags&TabSizeEight != 0 {

--- a/markdown.go
+++ b/markdown.go
@@ -82,7 +82,7 @@ const (
 	ListTypeTerm
 
 	ListItemContainsBlock
-	ListItemBeginningOfList
+	ListItemBeginningOfList // TODO: figure out if this is of any use now
 	ListItemEndOfList
 )
 
@@ -428,7 +428,7 @@ func (p *parser) parseRefsToAST() {
 	for i := 0; i < len(p.notes); i++ {
 		ref := p.notes[i]
 		block := p.addBlock(Item, nil)
-		block.ListFlags = ListTypeOrdered
+		block.ListFlags = flags | ListTypeOrdered
 		block.RefLink = ref.link
 		if ref.hasBlock {
 			flags |= ListItemContainsBlock

--- a/markdown.go
+++ b/markdown.go
@@ -394,8 +394,7 @@ func Parse(input []byte, opts Options) *Node {
 		p.notes = make([]*reference, 0)
 	}
 
-	first := firstPass(p, input)
-	secondPass(p, first)
+	p.block(firstPass(p, input))
 	// Walk the tree and finish up some of unfinished blocks
 	for p.tip != nil {
 		p.finalize(p.tip)
@@ -511,29 +510,6 @@ func firstPass(p *parser, input []byte) []byte {
 	}
 
 	return out.Bytes()
-}
-
-// second pass: actual rendering
-func secondPass(p *parser, input []byte) {
-	p.block(input)
-
-	if p.flags&Footnotes != 0 && len(p.notes) > 0 {
-		flags := ListItemBeginningOfList
-		for i := 0; i < len(p.notes); i++ {
-			ref := p.notes[i]
-			if ref.hasBlock {
-				flags |= ListItemContainsBlock
-				p.block(ref.title)
-			} else {
-				p.inline(nil, ref.title)
-			}
-			flags &^= ListItemBeginningOfList | ListItemContainsBlock
-		}
-	}
-
-	if p.nesting != 0 {
-		panic("Nesting level did not end at zero")
-	}
 }
 
 //

--- a/node.go
+++ b/node.go
@@ -69,20 +69,21 @@ func (t NodeType) String() string {
 	return nodeTypeNames[t]
 }
 
-// ListData contains fields relevant to a List node type.
+// ListData contains fields relevant to a List and Item node type.
 type ListData struct {
-	ListFlags  ListType
-	Tight      bool   // Skip <p>s around list item data if true
-	BulletChar byte   // '*', '+' or '-' in bullet lists
-	Delimiter  byte   // '.' or ')' after the number in ordered lists
-	RefLink    []byte // If not nil, turns this list item into a footnote item and triggers different rendering
+	ListFlags       ListType
+	Tight           bool   // Skip <p>s around list item data if true
+	BulletChar      byte   // '*', '+' or '-' in bullet lists
+	Delimiter       byte   // '.' or ')' after the number in ordered lists
+	RefLink         []byte // If not nil, turns this list item into a footnote item and triggers different rendering
+	IsFootnotesList bool   // This is a list of footnotes
 }
 
 // LinkData contains fields relevant to a Link node type.
 type LinkData struct {
-	Destination []byte
-	Title       []byte
-	NoteID      int
+	Destination []byte // Destination is what goes into a href
+	Title       []byte // Title is the tooltip thing that goes in a title attribute
+	NoteID      int    // NoteID contains a serial number of a footnote, zero if it's not a footnote
 }
 
 // CodeBlockData contains fields relevant to a CodeBlock node type.


### PR DESCRIPTION
Clean up footnotes part of an AST: don't force HTML-specific pieces there, just keep a clean list of footnotes. Since some renderers might want to process footnotes differently, let them know about footnotes by having a flag on that list.