### PR TITLE
v1: Set LIST_ITEM_END_OF_LIST when list is at end of document.

### DIFF
--- a/block.go
+++ b/block.go
@@ -1244,6 +1244,12 @@ gatherlines:
 		line = i
 	}
 
+	// If reached end of data, the Renderer.ListItem call we're going to make below
+	// is definitely the last in the list.
+	if line >= len(data) {
+		*flags |= LIST_ITEM_END_OF_LIST
+	}
+
 	rawBytes := raw.Bytes()
 
 	// render the contents of the list item


### PR DESCRIPTION
I ran into this while looking into a [bug in `markdownfmt`](https://github.com/shurcooL/markdownfmt/issues/30). I've realized I should really update to v2, and I promise to do that soon. However, this fix seems harmless and relatively easy to reason about. All current test are passing. I hope that's enough to merge it in.

I was going to write tests for this, but realized that it would be very very verbose. I'd have to create a mock implementation of a `blackfriday.Renderer`, then wrap it around a real renderer (because of the known limitation of parser/renderer of v1). But investing more into v1 doesn't make much sense.

The implementation details are the commit message, pasted here for convenience:

> The `LIST_ITEM_END_OF_LIST` flag is an internal flag passed to renderers when rendering list items. It's normally set for the last item in the list.
>
> This change fixes the issue where that flag wasn't set in situations where the Markdown document ends with the list being the last block level item in it.
>
> The cases above detect and set LIST_ITEM_END_OF_LIST flag when the list ends because another thing begins, but they miss it when the end of document is reached.