### PR TITLE
v2: Fix walk with non-container root nodes

### DIFF
--- a/node.go
+++ b/node.go
@@ -309,7 +309,7 @@ func newNodeWalker(root *Node) *nodeWalker {
 }
 
 func (nw *nodeWalker) next() {
-	if !nw.entering && nw.current == nw.root {
+	if (!nw.current.isContainer() || !nw.entering) && nw.current == nw.root {
 		nw.current = nil
 		return
 	}


### PR DESCRIPTION
When passed a non-container root node, the former algorithm would go on
walking down the rest of the tree beyond the root.

The former walk fix was supposed to do that but somehow the code
disappeared in the process.