### PR TITLE
Move TOC and OmitContents to HTML flags

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -1601,7 +1601,9 @@ func TestTOC(t *testing.T) {
 		"#",
 		"",
 	}
-	doTestsBlock(t, tests, TOC)
+	doTestsParam(t, tests, TestParams{
+		HTMLFlags: UseXHTML | TOC,
+	})
 }
 
 func TestOmitContents(t *testing.T) {
@@ -1625,9 +1627,13 @@ func TestOmitContents(t *testing.T) {
 		"#\n\nfoo",
 		"",
 	}
-	doTestsBlock(t, tests, TOC|OmitContents)
+	doTestsParam(t, tests, TestParams{
+		HTMLFlags: UseXHTML | TOC | OmitContents,
+	})
 	// Now run again: make sure OmitContents implies TOC
-	doTestsBlock(t, tests, OmitContents)
+	doTestsParam(t, tests, TestParams{
+		HTMLFlags: UseXHTML | OmitContents,
+	})
 }
 
 func TestCompletePage(t *testing.T) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -44,7 +44,6 @@ func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, s
 
 func runMarkdown(input string, params TestParams) string {
 	params.HTMLRendererParameters.Flags = params.HTMLFlags
-	params.HTMLRendererParameters.Extensions = params.Options.Extensions
 	renderer := NewHTMLRenderer(params.HTMLRendererParameters)
 	return string(Markdown([]byte(input), renderer, params.Options))
 }
@@ -54,8 +53,7 @@ func doTests(t *testing.T, tests []string) {
 	doTestsParam(t, tests, TestParams{
 		Options: DefaultOptions,
 		HTMLRendererParameters: HTMLRendererParameters{
-			Flags:      CommonHTMLFlags,
-			Extensions: CommonExtensions,
+			Flags: CommonHTMLFlags,
 		},
 	})
 }

--- a/html.go
+++ b/html.go
@@ -46,6 +46,8 @@ const (
 	SmartypantsDashes                             // Enable smart dashes (with Smartypants)
 	SmartypantsLatexDashes                        // Enable LaTeX-style dashes (with Smartypants)
 	SmartypantsAngledQuotes                       // Enable angled double quotes (with Smartypants) for double quotes rendering
+	TOC                                           // Generate a table of contents
+	OmitContents                                  // Skip the main contents (for a standalone table of contents)
 
 	TagName               = "[A-Za-z][A-Za-z0-9-]*"
 	AttributeName         = "[a-zA-Z_:][a-zA-Z0-9:._-]*"
@@ -90,8 +92,7 @@ type HTMLRendererParameters struct {
 	CSS   string // Optional CSS file URL (used if CompletePage is set)
 	Icon  string // Optional icon file URL (used if CompletePage is set)
 
-	Flags      HTMLFlags  // Flags allow customizing this renderer's behavior
-	Extensions Extensions // Extensions give Smartypants and HTML renderer access to Blackfriday's global extensions
+	Flags HTMLFlags // Flags allow customizing this renderer's behavior
 }
 
 // HTMLRenderer is a type that implements the Renderer interface for HTML output.
@@ -829,9 +830,9 @@ func (r *HTMLRenderer) Render(ast *Node) []byte {
 	//dump(ast)
 	var buff bytes.Buffer
 	r.writeDocumentHeader(&buff)
-	if r.Extensions&TOC != 0 || r.Extensions&OmitContents != 0 {
+	if r.Flags&TOC != 0 || r.Flags&OmitContents != 0 {
 		r.writeTOC(&buff, ast)
-		if r.Extensions&OmitContents != 0 {
+		if r.Flags&OmitContents != 0 {
 			return buff.Bytes()
 		}
 	}

--- a/markdown.go
+++ b/markdown.go
@@ -46,8 +46,6 @@ const (
 	AutoHeaderIDs                                 // Create the header ID from the text
 	BackslashLineBreak                            // Translate trailing backslashes into line breaks
 	DefinitionLists                               // Render definition lists
-	TOC                                           // Generate a table of contents
-	OmitContents                                  // Skip the main contents (for a standalone table of contents)
 
 	CommonHTMLFlags HTMLFlags = UseXHTML | Smartypants |
 		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
@@ -290,8 +288,7 @@ type Options struct {
 func MarkdownBasic(input []byte) []byte {
 	// set up the HTML renderer
 	renderer := NewHTMLRenderer(HTMLRendererParameters{
-		Flags:      UseXHTML,
-		Extensions: CommonExtensions,
+		Flags: UseXHTML,
 	})
 
 	// set up the parser
@@ -319,8 +316,7 @@ func MarkdownBasic(input []byte) []byte {
 func MarkdownCommon(input []byte) []byte {
 	// set up the HTML renderer
 	renderer := NewHTMLRenderer(HTMLRendererParameters{
-		Flags:      CommonHTMLFlags,
-		Extensions: CommonExtensions,
+		Flags: CommonHTMLFlags,
 	})
 	return Markdown(input, renderer, DefaultOptions)
 }


### PR DESCRIPTION
The root problem this commit fixes is the duplication of Extensions
field in HTMLRendererParameters. The duplication crept in there only to
support these two flags, so moving the flags solves the problem. They're
only used in renderer anyway.

Fixes #277.