### PR TITLE
Fix #180 again

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -604,6 +604,9 @@ func TestReferenceLink(t *testing.T) {
 
 		"[ref]\n   [ref]: ../url/ \"title\"\n",
 		"<p><a href=\"../url/\" title=\"title\">ref</a></p>\n",
+
+		"[link][ref]\n   [ref]: /url/",
+		"<p><a href=\"/url/\">link</a></p>\n",
 	}
 	doLinkTestsInline(t, tests)
 }

--- a/markdown.go
+++ b/markdown.go
@@ -639,9 +639,6 @@ func scanLinkRef(p *parser, data []byte, i int) (linkOffset, linkEnd, titleOffse
 	for i < len(data) && data[i] != ' ' && data[i] != '\t' && data[i] != '\n' && data[i] != '\r' {
 		i++
 	}
-	if i == len(data) {
-		return
-	}
 	linkEnd = i
 	if data[linkOffset] == '<' && data[linkEnd-1] == '>' {
 		linkOffset++


### PR DESCRIPTION
The check was introduced with d28de22, when fixing #172 and #173.
Then I removed it with bcd6dd8 when fixing #180
And then it was reintroduced with 232d06c when fixing regression.

It seems that the check can be removed again. All these cases now have
tests (including the one from 69f51af, which seems to have landed to v1
only, copying it here) and they all pass.

(As discussed in #311, where it was rediscovered)