### PR TITLE
Fix all headings wrongly referred to as headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ are a few of note:
 
 *   [github_flavored_markdown](https://godoc.org/github.com/shurcooL/github_flavored_markdown):
     provides a GitHub Flavored Markdown renderer with fenced code block
-    highlighting, clickable header anchor links.
+    highlighting, clickable heading anchor links.
 
     It's not customizable, and its goal is to produce HTML output
     equivalent to the [GitHub Markdown API endpoint](https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode),

--- a/block_test.go
+++ b/block_test.go
@@ -144,7 +144,7 @@ func TestPrefixHeaderSpaceExtension(t *testing.T) {
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li><p>Nested list</p>\n\n" +
 			"<h1>Nested header</h1></li>\n</ul></li>\n</ul>\n",
 	}
-	doTestsBlock(t, tests, SpaceHeaders)
+	doTestsBlock(t, tests, SpaceHeadings)
 }
 
 func TestPrefixHeaderIdExtension(t *testing.T) {
@@ -204,7 +204,7 @@ func TestPrefixHeaderIdExtension(t *testing.T) {
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li><p>Nested list</p>\n\n" +
 			"<h1 id=\"someid\">Nested header</h1></li>\n</ul></li>\n</ul>\n",
 	}
-	doTestsBlock(t, tests, HeaderIDs)
+	doTestsBlock(t, tests, HeadingIDs)
 }
 
 func TestPrefixHeaderIdExtensionWithPrefixAndSuffix(t *testing.T) {
@@ -248,12 +248,12 @@ func TestPrefixHeaderIdExtensionWithPrefixAndSuffix(t *testing.T) {
 	}
 
 	parameters := HTMLRendererParameters{
-		HeaderIDPrefix: "PRE:",
-		HeaderIDSuffix: ":POST",
+		HeadingIDPrefix: "PRE:",
+		HeadingIDSuffix: ":POST",
 	}
 
 	doTestsParam(t, tests, TestParams{
-		Options:                Options{Extensions: HeaderIDs},
+		Options:                Options{Extensions: HeadingIDs},
 		HTMLFlags:              UseXHTML,
 		HTMLRendererParameters: parameters,
 	})
@@ -307,7 +307,7 @@ func TestPrefixAutoHeaderIdExtension(t *testing.T) {
 		"# Header\n\n# Header 1\n\n# Header\n\n# Header",
 		"<h1 id=\"header\">Header</h1>\n\n<h1 id=\"header-1\">Header 1</h1>\n\n<h1 id=\"header-1-1\">Header</h1>\n\n<h1 id=\"header-1-2\">Header</h1>\n",
 	}
-	doTestsBlock(t, tests, AutoHeaderIDs)
+	doTestsBlock(t, tests, AutoHeadingIDs)
 }
 
 func TestPrefixAutoHeaderIdExtensionWithPrefixAndSuffix(t *testing.T) {
@@ -360,12 +360,12 @@ func TestPrefixAutoHeaderIdExtensionWithPrefixAndSuffix(t *testing.T) {
 	}
 
 	parameters := HTMLRendererParameters{
-		HeaderIDPrefix: "PRE:",
-		HeaderIDSuffix: ":POST",
+		HeadingIDPrefix: "PRE:",
+		HeadingIDSuffix: ":POST",
 	}
 
 	doTestsParam(t, tests, TestParams{
-		Options:                Options{Extensions: AutoHeaderIDs},
+		Options:                Options{Extensions: AutoHeadingIDs},
 		HTMLFlags:              UseXHTML,
 		HTMLRendererParameters: parameters,
 	})
@@ -376,7 +376,7 @@ func TestPrefixMultipleHeaderExtensions(t *testing.T) {
 		"# Header\n\n# Header {#header}\n\n# Header 1",
 		"<h1 id=\"header\">Header</h1>\n\n<h1 id=\"header-1\">Header</h1>\n\n<h1 id=\"header-1-1\">Header 1</h1>\n",
 	}
-	doTestsBlock(t, tests, AutoHeaderIDs|HeaderIDs)
+	doTestsBlock(t, tests, AutoHeadingIDs|HeadingIDs)
 }
 
 func TestUnderlineHeaders(t *testing.T) {
@@ -476,7 +476,7 @@ func TestUnderlineHeadersAutoIDs(t *testing.T) {
 		"Header 1\n========\n\nHeader 1\n========\n",
 		"<h1 id=\"header-1\">Header 1</h1>\n\n<h1 id=\"header-1-1\">Header 1</h1>\n",
 	}
-	doTestsBlock(t, tests, AutoHeaderIDs)
+	doTestsBlock(t, tests, AutoHeadingIDs)
 }
 
 func TestHorizontalRule(t *testing.T) {

--- a/markdown.go
+++ b/markdown.go
@@ -36,14 +36,14 @@ const (
 	Autolink                                      // Detect embedded URLs that are not explicitly marked
 	Strikethrough                                 // Strikethrough text using ~~test~~
 	LaxHTMLBlocks                                 // Loosen up HTML block parsing rules
-	SpaceHeaders                                  // Be strict about prefix header rules
+	SpaceHeadings                                 // Be strict about prefix heading rules
 	HardLineBreak                                 // Translate newlines into line breaks
 	TabSizeEight                                  // Expand tabs to eight spaces instead of four
 	Footnotes                                     // Pandoc-style footnotes
 	NoEmptyLineBeforeBlock                        // No need to insert an empty line to start a (code, quote, ordered list, unordered list) block
-	HeaderIDs                                     // specify header IDs  with {#id}
+	HeadingIDs                                    // specify heading IDs  with {#id}
 	Titleblock                                    // Titleblock ala pandoc
-	AutoHeaderIDs                                 // Create the header ID from the text
+	AutoHeadingIDs                                // Create the heading ID from the text
 	BackslashLineBreak                            // Translate trailing backslashes into line breaks
 	DefinitionLists                               // Render definition lists
 
@@ -51,7 +51,7 @@ const (
 		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
-		Autolink | Strikethrough | SpaceHeaders | HeaderIDs |
+		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |
 		BackslashLineBreak | DefinitionLists
 )
 
@@ -310,9 +310,9 @@ func MarkdownBasic(input []byte) []byte {
 //
 // * Strikethrough support
 //
-// * Strict header parsing
+// * Strict heading parsing
 //
-// * Custom Header IDs
+// * Custom Heading IDs
 func MarkdownCommon(input []byte) []byte {
 	// set up the HTML renderer
 	renderer := NewHTMLRenderer(HTMLRendererParameters{
@@ -392,7 +392,7 @@ func Parse(input []byte, opts Options) *Node {
 	}
 	// Walk the tree again and process inline markdown in each block
 	p.doc.Walk(func(node *Node, entering bool) WalkStatus {
-		if node.Type == Paragraph || node.Type == Header || node.Type == TableCell {
+		if node.Type == Paragraph || node.Type == Heading || node.Type == TableCell {
 			p.inline(node, node.content)
 			node.content = nil
 		}
@@ -433,7 +433,7 @@ func (p *parser) parseRefsToAST() {
 	finalizeList(block)
 	p.tip = above
 	block.Walk(func(node *Node, entering bool) WalkStatus {
-		if node.Type == Paragraph || node.Type == Header {
+		if node.Type == Paragraph || node.Type == Heading {
 			p.inline(node, node.content)
 			node.content = nil
 		}

--- a/node.go
+++ b/node.go
@@ -17,7 +17,7 @@ const (
 	List
 	Item
 	Paragraph
-	Header
+	Heading
 	HorizontalRule
 	Emph
 	Strong
@@ -44,7 +44,7 @@ var nodeTypeNames = []string{
 	List:           "List",
 	Item:           "Item",
 	Paragraph:      "Paragraph",
-	Header:         "Header",
+	Heading:        "Heading",
 	HorizontalRule: "HorizontalRule",
 	Emph:           "Emph",
 	Strong:         "Strong",
@@ -102,10 +102,10 @@ type TableCellData struct {
 	Align    CellAlignFlags // This holds the value for align attribute
 }
 
-// HeaderData contains fields relevant to a Header node type.
-type HeaderData struct {
+// HeadingData contains fields relevant to a Heading node type.
+type HeadingData struct {
 	Level        int    // This holds the heading level number
-	HeaderID     string // This might hold header ID, if present
+	HeadingID    string // This might hold heading ID, if present
 	IsTitleblock bool   // Specifies whether it's a title block
 }
 
@@ -122,7 +122,7 @@ type Node struct {
 
 	Literal []byte // Text contents of the leaf nodes
 
-	HeaderData    // Populated if Type is Header
+	HeadingData   // Populated if Type is Heading
 	ListData      // Populated if Type is List
 	CodeBlockData // Populated if Type is CodeBlock
 	LinkData      // Populated if Type is Link
@@ -211,7 +211,7 @@ func (n *Node) isContainer() bool {
 		fallthrough
 	case Paragraph:
 		fallthrough
-	case Header:
+	case Heading:
 		fallthrough
 	case Emph:
 		fallthrough


### PR DESCRIPTION
I've left test cases alone since can't lean on the compiler for
crosschecking there.

Fixes #330.