### PR TITLE
Clean up Options struct and Markdown func

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -84,7 +84,7 @@ func TestPrefixHeaderNoExtensions(t *testing.T) {
 		"#Header 1 #\\##\n",
 		"<h1>Header 1 ##</h1>\n",
 	}
-	doTestsBlock(t, tests, 0)
+	doTestsBlock(t, tests, NoExtensions)
 }
 
 func TestPrefixHeaderSpaceExtension(t *testing.T) {
@@ -426,7 +426,7 @@ func TestUnderlineHeaders(t *testing.T) {
 		"Double underline\n=====\n=====\n",
 		"<h1>Double underline</h1>\n\n<p>=====</p>\n",
 	}
-	doTestsBlock(t, tests, 0)
+	doTestsBlock(t, tests, NoExtensions)
 }
 
 func TestUnderlineHeadersAutoIDs(t *testing.T) {
@@ -541,7 +541,7 @@ func TestHorizontalRule(t *testing.T) {
 		"---\n***\n___\n",
 		"<hr />\n\n<hr />\n\n<hr />\n",
 	}
-	doTestsBlock(t, tests, 0)
+	doTestsBlock(t, tests, NoExtensions)
 }
 
 func TestUnorderedList(t *testing.T) {
@@ -652,7 +652,7 @@ func TestUnorderedList(t *testing.T) {
 		"* List\n\n    * sublist\n\n    normal text\n\n    * another sublist\n",
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li>sublist</li>\n</ul>\n\n<p>normal text</p>\n\n<ul>\n<li>another sublist</li>\n</ul></li>\n</ul>\n",
 	}
-	doTestsBlock(t, tests, 0)
+	doTestsBlock(t, tests, NoExtensions)
 }
 
 func TestOrderedList(t *testing.T) {
@@ -748,7 +748,7 @@ func TestOrderedList(t *testing.T) {
 		"1. numbers\n1. are ignored\n",
 		"<ol>\n<li>numbers</li>\n<li>are ignored</li>\n</ol>\n",
 	}
-	doTestsBlock(t, tests, 0)
+	doTestsBlock(t, tests, NoExtensions)
 }
 
 func TestDefinitionList(t *testing.T) {
@@ -903,7 +903,7 @@ func TestPreformattedHtml(t *testing.T) {
 		"Paragraph\n\n<div>\nHow about here? >&<\n</div>\n\nAnd here?\n",
 		"<p>Paragraph</p>\n\n<div>\nHow about here? >&<\n</div>\n\n<p>And here?</p>\n",
 	}
-	doTestsBlock(t, tests, 0)
+	doTestsBlock(t, tests, NoExtensions)
 }
 
 func TestPreformattedHtmlLax(t *testing.T) {
@@ -1483,7 +1483,7 @@ func TestBlockComments(t *testing.T) {
 		"Some text\n\n<!--\n\n<div><p>Commented</p>\n<span>html</span></div>\n-->\n",
 		"<p>Some text</p>\n\n<!--\n\n<div><p>Commented</p>\n<span>html</span></div>\n-->\n",
 	}
-	doTestsBlock(t, tests, 0)
+	doTestsBlock(t, tests, NoExtensions)
 }
 
 func TestTOC(t *testing.T) {
@@ -1602,6 +1602,7 @@ func TestTOC(t *testing.T) {
 		"",
 	}
 	doTestsParam(t, tests, TestParams{
+		Options:   Options{Extensions: NoExtensions},
 		HTMLFlags: UseXHTML | TOC,
 	})
 }
@@ -1628,10 +1629,12 @@ func TestOmitContents(t *testing.T) {
 		"",
 	}
 	doTestsParam(t, tests, TestParams{
+		Options:   Options{Extensions: NoExtensions},
 		HTMLFlags: UseXHTML | TOC | OmitContents,
 	})
 	// Now run again: make sure OmitContents implies TOC
 	doTestsParam(t, tests, TestParams{
+		Options:   Options{Extensions: NoExtensions},
 		HTMLFlags: UseXHTML | OmitContents,
 	})
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -44,8 +44,8 @@ func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, s
 
 func runMarkdown(input string, params TestParams) string {
 	params.HTMLRendererParameters.Flags = params.HTMLFlags
-	renderer := NewHTMLRenderer(params.HTMLRendererParameters)
-	return string(Markdown([]byte(input), renderer, params.Options))
+	params.Options.Renderer = NewHTMLRenderer(params.HTMLRendererParameters)
+	return string(Markdown([]byte(input), params.Options))
 }
 
 // doTests runs full document tests using MarkdownCommon configuration.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -51,7 +51,7 @@ func runMarkdown(input string, params TestParams) string {
 // doTests runs full document tests using MarkdownCommon configuration.
 func doTests(t *testing.T, tests []string) {
 	doTestsParam(t, tests, TestParams{
-		Options: DefaultOptions,
+		Options: defaultOptions,
 		HTMLRendererParameters: HTMLRendererParameters{
 			Flags: CommonHTMLFlags,
 		},

--- a/markdown.go
+++ b/markdown.go
@@ -56,7 +56,12 @@ const (
 )
 
 // DefaultOptions is a convenience variable with all the options that are
-// enabled by default.
+// enabled by default. Namely, a set of CommonExtensions plus the default
+// HTML renderer configured with a set of CommonHTMLFlags.
+//
+// Do not modify DefaultOptions variable since that might have side effects on
+// later invocations of Markdown* functions. If you need to customize behavior,
+// pass your own copy of Options to the Markdown function.
 var DefaultOptions = Options{
 	Extensions: CommonExtensions,
 	Renderer: NewHTMLRenderer(HTMLRendererParameters{
@@ -301,7 +306,8 @@ func MarkdownBasic(input []byte) []byte {
 }
 
 // MarkdownCommon is a convenience function for simple rendering. It calls
-// Markdown with most useful extensions enabled, including:
+// Markdown with DefaultOptions, which contain the most useful extensions
+// enabled, including:
 //
 // * Smartypants processing with smart fractions and LaTeX dashes
 //
@@ -322,12 +328,12 @@ func MarkdownCommon(input []byte) []byte {
 	return Markdown(input, DefaultOptions)
 }
 
-// Markdown is the main rendering function.
-// It parses and renders a block of markdown-encoded text.
-// The supplied options contain a Renderer used to format the output, and
-// extensions that dictate which non-standard extensions are enabled.
+// Markdown is the main entry point. It parses and renders a block of
+// markdown-formatted text. The supplied options contain a Renderer used to
+// format the output, and extensions that dictate which non-standard extensions
+// are enabled.
 //
-// If options.Renderer is nil, the supplied HTML renderer is used.
+// If options.Renderer is nil, then DefaultOptions.Renderer is used.
 func Markdown(input []byte, options Options) []byte {
 	if options.Renderer == nil {
 		options.Renderer = DefaultOptions.Renderer


### PR DESCRIPTION
Move renderer from a formal parameter to Markdown to an Options member.

This is an (intentionally conflicting) alternative to #328. Only one of them should land, I'm providing both in order to compare them against each other in terms of actual code.