### PR TITLE
Add rel=noopener

### DIFF
--- a/html.go
+++ b/html.go
@@ -32,6 +32,7 @@ const (
 	HTML_SAFELINK                              // only link to trusted protocols
 	HTML_NOFOLLOW_LINKS                        // only link with rel="nofollow"
 	HTML_NOREFERRER_LINKS                      // only link with rel="noreferrer"
+	HTML_NOOPENER_LINKS                        // only link with rel="noopener"
 	HTML_HREF_TARGET_BLANK                     // add a blank target
 	HTML_TOC                                   // generate a table of contents
 	HTML_OMIT_CONTENTS                         // skip the main contents (for a standalone table of contents)
@@ -456,6 +457,9 @@ func (options *Html) AutoLink(out *bytes.Buffer, link []byte, kind int) {
 	if options.flags&HTML_NOREFERRER_LINKS != 0 && !isRelativeLink(link) {
 		relAttrs = append(relAttrs, "noreferrer")
 	}
+	if options.flags&HTML_NOOPENER_LINKS != 0 && !isRelativeLink(link) {
+		relAttrs = append(relAttrs, "noopener")
+	}
 	if len(relAttrs) > 0 {
 		out.WriteString(fmt.Sprintf("\" rel=\"%s", strings.Join(relAttrs, " ")))
 	}
@@ -569,6 +573,9 @@ func (options *Html) Link(out *bytes.Buffer, link []byte, title []byte, content 
 	}
 	if options.flags&HTML_NOREFERRER_LINKS != 0 && !isRelativeLink(link) {
 		relAttrs = append(relAttrs, "noreferrer")
+	}
+	if options.flags&HTML_NOOPENER_LINKS != 0 && !isRelativeLink(link) {
+		relAttrs = append(relAttrs, "noopener")
 	}
 	if len(relAttrs) > 0 {
 		out.WriteString(fmt.Sprintf("\" rel=\"%s", strings.Join(relAttrs, " ")))

--- a/inline_test.go
+++ b/inline_test.go
@@ -615,6 +615,16 @@ func TestRelAttrLink(t *testing.T) {
 	doTestsInlineParam(t, noreferrerTests, Options{}, HTML_SAFELINK|HTML_NOREFERRER_LINKS,
 		HtmlRendererParameters{})
 
+	var noopenerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"noopener\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, noopenerTests, Options{}, HTML_SAFELINK|HTML_NOOPENER_LINKS,
+		HtmlRendererParameters{})
+
 	var nofollownoreferrerTests = []string{
 		"[foo](http://bar.com/foo/)\n",
 		"<p><a href=\"http://bar.com/foo/\" rel=\"nofollow noreferrer\">foo</a></p>\n",
@@ -623,6 +633,36 @@ func TestRelAttrLink(t *testing.T) {
 		"<p><a href=\"/bar/\">foo</a></p>\n",
 	}
 	doTestsInlineParam(t, nofollownoreferrerTests, Options{}, HTML_SAFELINK|HTML_NOFOLLOW_LINKS|HTML_NOREFERRER_LINKS,
+		HtmlRendererParameters{})
+
+	var nofollownoopenerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"nofollow noopener\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, nofollownoopenerTests, Options{}, HTML_SAFELINK|HTML_NOFOLLOW_LINKS|HTML_NOOPENER_LINKS,
+		HtmlRendererParameters{})
+
+	var noreferrernoopenerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"noreferrer noopener\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, noreferrernoopenerTests, Options{}, HTML_SAFELINK|HTML_NOREFERRER_LINKS|HTML_NOOPENER_LINKS,
+		HtmlRendererParameters{})
+
+	var nofollownoreferrernoopenerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"nofollow noreferrer noopener\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, nofollownoreferrernoopenerTests, Options{}, HTML_SAFELINK|HTML_NOFOLLOW_LINKS|HTML_NOREFERRER_LINKS|HTML_NOOPENER_LINKS,
 		HtmlRendererParameters{})
 }
 


### PR DESCRIPTION
For better or worse, browsers have implemented a security and performance feature for links using the `rel=noopener`, preventing the hijacking of the `window.opener.location` object for pages opened with a `_blank` target, which becomes important for sites with UGC.

This commit adds to Blackfriday the ability for users to configure an option to enable the `rel=noopener` attribute.

Refs:

- https://developers.google.com/web/tools/lighthouse/audits/noopener
- https://mathiasbynens.github.io/rel-noopener/
- https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/