### PR TITLE
Failing test cases for #291

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -577,6 +577,9 @@ func TestInlineLink(t *testing.T) {
 
 		"[disambiguation](http://en.wikipedia.org/wiki/Disambiguation_(disambiguation))",
 		"<p><a href=\"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)\">disambiguation</a></p>\n",
+
+		"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)",
+		"<p><a href=\"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)\">http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)</a></p>\n",
 	}
 	doLinkTestsInline(t, tests)
 
@@ -745,6 +748,9 @@ func TestAutoLink(t *testing.T) {
 	var tests = []string{
 		"http://foo.com/\n",
 		"<p><a href=\"http://foo.com/\">http://foo.com/</a></p>\n",
+
+		"http://foo.com/bar/Baz_(baz)",
+		"<p><a href=\"http://foo.com/bar/Baz_(baz)\">http://foo.com/bar/Baz_(baz)</a></p>\n",
 
 		"1 http://foo.com/\n",
 		"<p>1 <a href=\"http://foo.com/\">http://foo.com/</a></p>\n",


### PR DESCRIPTION
Links with parenthesis (like wikipedia links) are not correct when using autolinks