### PR TITLE
Handle Parenthesis in links properly

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -244,8 +244,6 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 		i++
 	}
 
-	brace := 0
-
 	// look for the matching closing bracket
 	for level := 1; level > 0 && i < len(data); i++ {
 		switch {
@@ -279,6 +277,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 		i++
 	}
 
+	parenthesis := 0
 	switch {
 	// inline style link
 	case i < len(data) && data[i] == '(':
@@ -291,7 +290,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 
 		linkB := i
 
-		// look for link end: ' " ), check for new opening braces and take this
+		// look for link end: ' " ), check for new opening parenthesis and take this
 		// into account, this may lead for overshooting and probably will require
 		// some fine-tuning.
 	findlinkend:
@@ -301,14 +300,14 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 				i += 2
 
 			case data[i] == '(':
-				brace++
+				parenthesis++
 				i++
 
 			case data[i] == ')':
-				if brace <= 0 {
+				if parenthesis <= 0 {
 					break findlinkend
 				}
-				brace--
+				parenthesis--
 				i++
 
 			case data[i] == '\'' || data[i] == '"':
@@ -793,10 +792,6 @@ func autoLink(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			}
 
 			bufEnd--
-		}
-
-		if openDelim == 0 {
-			linkEnd--
 		}
 	}
 

--- a/inline_test.go
+++ b/inline_test.go
@@ -570,13 +570,16 @@ func TestInlineLink(t *testing.T) {
 
 		// no closing ), autolinking detects the url next
 		"[disambiguation](http://en.wikipedia.org/wiki/Disambiguation_(disambiguation) is the",
-		"<p>[disambiguation](<a href=\"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation\">http://en.wikipedia.org/wiki/Disambiguation_(disambiguation</a>) is the</p>\n",
+		"<p>[disambiguation](<a href=\"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)\">http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)</a> is the</p>\n",
 
 		"[disambiguation](http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)) is the",
 		"<p><a href=\"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)\">disambiguation</a> is the</p>\n",
 
 		"[disambiguation](http://en.wikipedia.org/wiki/Disambiguation_(disambiguation))",
 		"<p><a href=\"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)\">disambiguation</a></p>\n",
+
+		"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)",
+		"<p><a href=\"http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)\">http://en.wikipedia.org/wiki/Disambiguation_(disambiguation)</a></p>\n",
 	}
 	doLinkTestsInline(t, tests)
 
@@ -745,6 +748,9 @@ func TestAutoLink(t *testing.T) {
 	var tests = []string{
 		"http://foo.com/\n",
 		"<p><a href=\"http://foo.com/\">http://foo.com/</a></p>\n",
+
+		"http://foo.com/bar/Baz_(baz)",
+		"<p><a href=\"http://foo.com/bar/Baz_(baz)\">http://foo.com/bar/Baz_(baz)</a></p>\n",
 
 		"1 http://foo.com/\n",
 		"<p>1 <a href=\"http://foo.com/\">http://foo.com/</a></p>\n",


### PR DESCRIPTION
Links with parenthesis (like wikipedia links) are not correct when using autolinks

Properly handle parenthesis in links.

Fixes #291