### PR TITLE
fix duplicate and recursive footnotes. (#241)

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -488,7 +488,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			}
 
 			p.notes = append(p.notes, ref)
-			p.notesRecord[string(ref.link)] = true
+			p.notesRecord[string(ref.link)] = struct{}{}
 
 			link = ref.link
 			title = ref.title
@@ -502,7 +502,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			if t == linkDeferredFootnote && !p.isFootnote(lr) {
 				lr.noteId = len(p.notes) + 1
 				p.notes = append(p.notes, lr)
-				p.notesRecord[string(lr.link)] = true
+				p.notesRecord[string(lr.link)] = struct{}{}
 			}
 
 			// keep link and title from reference

--- a/inline.go
+++ b/inline.go
@@ -498,7 +498,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 				return 0
 			}
 
-			if t == linkDeferredFootnote {
+			if t == linkDeferredFootnote && !p.isFootnote(lr) {
 				lr.noteId = len(p.notes) + 1
 				p.notes = append(p.notes, lr)
 			}

--- a/inline.go
+++ b/inline.go
@@ -488,6 +488,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			}
 
 			p.notes = append(p.notes, ref)
+			p.notesRecord[string(ref.link)] = true
 
 			link = ref.link
 			title = ref.title
@@ -501,6 +502,7 @@ func link(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 			if t == linkDeferredFootnote && !p.isFootnote(lr) {
 				lr.noteId = len(p.notes) + 1
 				p.notes = append(p.notes, lr)
+				p.notesRecord[string(lr.link)] = true
 			}
 
 			// keep link and title from reference

--- a/inline_test.go
+++ b/inline_test.go
@@ -1024,6 +1024,28 @@ what happens here
 </ol>
 </div>
 `,
+	`testing footnotes.[^a]
+
+test footnotes the second.[^b]
+
+[^a]: This is the first note[^a].
+[^b]: this is the second note.[^a]
+`,
+	`<p>testing footnotes.<sup class="footnote-ref" id="fnref:a"><a rel="footnote" href="#fn:a">1</a></sup></p>
+
+<p>test footnotes the second.<sup class="footnote-ref" id="fnref:b"><a rel="footnote" href="#fn:b">2</a></sup></p>
+<div class="footnotes">
+
+<hr />
+
+<ol>
+<li id="fn:a">This is the first note<sup class="footnote-ref" id="fnref:a"><a rel="footnote" href="#fn:a">1</a></sup>.
+</li>
+<li id="fn:b">this is the second note.<sup class="footnote-ref" id="fnref:a"><a rel="footnote" href="#fn:a">1</a></sup>
+</li>
+</ol>
+</div>
+`,
 }
 
 func TestFootnotes(t *testing.T) {
@@ -1073,6 +1095,34 @@ func TestNestedFootnotes(t *testing.T) {
 <li id="fn:fn1">Asterisk<sup class="footnote-ref" id="fnref:fn2"><a rel="footnote" href="#fn:fn2">2</a></sup>
 </li>
 <li id="fn:fn2">Obelisk
+</li>
+</ol>
+</div>
+`,
+		`This uses footnote A.[^A]
+
+This uses footnote C.[^C]
+
+[^A]:
+  A note. use itself.[^A]
+[^B]:
+  B note, uses A to test duplicate.[^A]
+[^C]:
+  C note, uses B.[^B]
+`,
+		`<p>This uses footnote A.<sup class="footnote-ref" id="fnref:A"><a rel="footnote" href="#fn:A">1</a></sup></p>
+
+<p>This uses footnote C.<sup class="footnote-ref" id="fnref:C"><a rel="footnote" href="#fn:C">2</a></sup></p>
+<div class="footnotes">
+
+<hr />
+
+<ol>
+<li id="fn:A">A note. use itself.<sup class="footnote-ref" id="fnref:A"><a rel="footnote" href="#fn:A">1</a></sup>
+</li>
+<li id="fn:C">C note, uses B.<sup class="footnote-ref" id="fnref:B"><a rel="footnote" href="#fn:B">3</a></sup>
+</li>
+<li id="fn:B">B note, uses A to test duplicate.<sup class="footnote-ref" id="fnref:A"><a rel="footnote" href="#fn:A">1</a></sup>
 </li>
 </ol>
 </div>

--- a/markdown.go
+++ b/markdown.go
@@ -218,7 +218,8 @@ type parser struct {
 	// Footnotes need to be ordered as well as available to quickly check for
 	// presence. If a ref is also a footnote, it's stored both in refs and here
 	// in notes. Slice is nil if footnotes not enabled.
-	notes []*reference
+	notes       []*reference
+	notesRecord map[string]bool
 }
 
 func (p *parser) getRef(refid string) (ref *reference, found bool) {
@@ -242,13 +243,8 @@ func (p *parser) getRef(refid string) (ref *reference, found bool) {
 }
 
 func (p *parser) isFootnote(ref *reference) bool {
-	for _, v := range p.notes {
-		if string(ref.link) == string(v.link) {
-			return true
-		}
-	}
-
-	return false
+	_, ok := p.notesRecord[string(ref.link)]
+	return ok
 }
 
 //
@@ -386,6 +382,7 @@ func MarkdownOptions(input []byte, renderer Renderer, opts Options) []byte {
 
 	if extensions&EXTENSION_FOOTNOTES != 0 {
 		p.notes = make([]*reference, 0)
+		p.notesRecord = make(map[string]bool)
 	}
 
 	first := firstPass(p, input)

--- a/markdown.go
+++ b/markdown.go
@@ -241,6 +241,16 @@ func (p *parser) getRef(refid string) (ref *reference, found bool) {
 	return ref, found
 }
 
+func (p *parser) isFootnote(ref *reference) bool {
+	for _, v := range p.notes {
+		if string(ref.link) == string(v.link) {
+			return true
+		}
+	}
+
+	return false
+}
+
 //
 //
 // Public interface

--- a/markdown.go
+++ b/markdown.go
@@ -219,7 +219,7 @@ type parser struct {
 	// presence. If a ref is also a footnote, it's stored both in refs and here
 	// in notes. Slice is nil if footnotes not enabled.
 	notes       []*reference
-	notesRecord map[string]bool
+	notesRecord map[string]struct{}
 }
 
 func (p *parser) getRef(refid string) (ref *reference, found bool) {
@@ -382,7 +382,7 @@ func MarkdownOptions(input []byte, renderer Renderer, opts Options) []byte {
 
 	if extensions&EXTENSION_FOOTNOTES != 0 {
 		p.notes = make([]*reference, 0)
-		p.notesRecord = make(map[string]bool)
+		p.notesRecord = make(map[string]struct{})
 	}
 
 	first := firstPass(p, input)


### PR DESCRIPTION
Fix the infinite loop when there is a self-refer footnote by checking if
the reference is already added into parser.notes.

It also fixes of creating duplicate footnotes through this modification.

Add coresponding testcase.