### PR TITLE
Fix for issue russross/blackfriday#239

### DIFF
--- a/block.go
+++ b/block.go
@@ -1293,7 +1293,7 @@ gatherlines:
 			}
 		}
 		// we are in a codeblock, write line, and continue
-		if codeBlockMarker != "" {
+		if codeBlockMarker != "" || marker != "" {
 			raw.Write(data[line+indentIndex : i])
 			line = i
 			continue gatherlines

--- a/block_test.go
+++ b/block_test.go
@@ -1458,6 +1458,17 @@ func TestFencedCodeBlock_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 	doTestsBlock(t, tests, FencedCode|NoEmptyLineBeforeBlock)
 }
 
+func TestListWithFencedCodeBlock(t *testing.T) {
+	var tests = []string{
+		"1. one\n\n    ```\n    code\n    ```\n\n2. two\n",
+		"<ol>\n<li><p>one</p>\n\n<pre><code>code\n</code></pre></li>\n\n<li><p>two</p></li>\n</ol>\n",
+		// https://github.com/russross/blackfriday/issues/239
+		"1. one\n\n    ```\n    - code\n    ```\n\n2. two\n",
+		"<ol>\n<li><p>one</p>\n\n<pre><code>- code\n</code></pre></li>\n\n<li><p>two</p></li>\n</ol>\n",
+	}
+	doTestsBlock(t, tests, FencedCode)
+}
+
 func TestTitleBlock_EXTENSION_TITLEBLOCK(t *testing.T) {
 	var tests = []string{
 		"% Some title\n" +


### PR DESCRIPTION

Fix for issue russross/blackfriday#239

This appears to also work in V1, although this PR is for V2

The following would confuse the `- codeline` as if it were a start of a nested list.

```
- line

    ```
    - codeline
    ```
```

The PR checks if a code fence is found, and don't use code to figure out if a list item has ended.

a code review is most welcome as I'm sure I'm missing something.

thanks!

n
