### PR TITLE
Unexport a bunch of constants private to HTML renderer

### DIFF
--- a/html.go
+++ b/html.go
@@ -47,27 +47,27 @@ const (
 	TOC                                           // Generate a table of contents
 )
 
-const (
-	tagName               = "[A-Za-z][A-Za-z0-9-]*"
-	attributeName         = "[a-zA-Z_:][a-zA-Z0-9:._-]*"
-	unquotedValue         = "[^\"'=<>`\\x00-\\x20]+"
-	singleQuotedValue     = "'[^']*'"
-	doubleQuotedValue     = "\"[^\"]*\""
-	attributeValue        = "(?:" + unquotedValue + "|" + singleQuotedValue + "|" + doubleQuotedValue + ")"
-	attributeValueSpec    = "(?:" + "\\s*=" + "\\s*" + attributeValue + ")"
-	attribute             = "(?:" + "\\s+" + attributeName + attributeValueSpec + "?)"
-	openTag               = "<" + tagName + attribute + "*" + "\\s*/?>"
-	closeTag              = "</" + tagName + "\\s*[>]"
-	htmlComment           = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->"
-	processingInstruction = "[<][?].*?[?][>]"
-	declaration           = "<![A-Z]+" + "\\s+[^>]*>"
-	cdata                 = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>"
-	htmlTag               = "(?:" + openTag + "|" + closeTag + "|" + htmlComment + "|" +
-		processingInstruction + "|" + declaration + "|" + cdata + ")"
-)
-
 var (
 	htmlTagRe = regexp.MustCompile("(?i)^" + htmlTag)
+)
+
+const (
+	htmlTag = "(?:" + openTag + "|" + closeTag + "|" + htmlComment + "|" +
+		processingInstruction + "|" + declaration + "|" + cdata + ")"
+	closeTag              = "</" + tagName + "\\s*[>]"
+	openTag               = "<" + tagName + attribute + "*" + "\\s*/?>"
+	attribute             = "(?:" + "\\s+" + attributeName + attributeValueSpec + "?)"
+	attributeValue        = "(?:" + unquotedValue + "|" + singleQuotedValue + "|" + doubleQuotedValue + ")"
+	attributeValueSpec    = "(?:" + "\\s*=" + "\\s*" + attributeValue + ")"
+	attributeName         = "[a-zA-Z_:][a-zA-Z0-9:._-]*"
+	cdata                 = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>"
+	declaration           = "<![A-Z]+" + "\\s+[^>]*>"
+	doubleQuotedValue     = "\"[^\"]*\""
+	htmlComment           = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->"
+	processingInstruction = "[<][?].*?[?][>]"
+	singleQuotedValue     = "'[^']*'"
+	tagName               = "[A-Za-z][A-Za-z0-9-]*"
+	unquotedValue         = "[^\"'=<>`\\x00-\\x20]+"
 )
 
 // HTMLRendererParameters is a collection of supplementary parameters tweaking

--- a/html.go
+++ b/html.go
@@ -45,27 +45,29 @@ const (
 	SmartypantsLatexDashes                        // Enable LaTeX-style dashes (with Smartypants)
 	SmartypantsAngledQuotes                       // Enable angled double quotes (with Smartypants) for double quotes rendering
 	TOC                                           // Generate a table of contents
+)
 
-	TagName               = "[A-Za-z][A-Za-z0-9-]*"
-	AttributeName         = "[a-zA-Z_:][a-zA-Z0-9:._-]*"
-	UnquotedValue         = "[^\"'=<>`\\x00-\\x20]+"
-	SingleQuotedValue     = "'[^']*'"
-	DoubleQuotedValue     = "\"[^\"]*\""
-	AttributeValue        = "(?:" + UnquotedValue + "|" + SingleQuotedValue + "|" + DoubleQuotedValue + ")"
-	AttributeValueSpec    = "(?:" + "\\s*=" + "\\s*" + AttributeValue + ")"
-	Attribute             = "(?:" + "\\s+" + AttributeName + AttributeValueSpec + "?)"
-	OpenTag               = "<" + TagName + Attribute + "*" + "\\s*/?>"
-	CloseTag              = "</" + TagName + "\\s*[>]"
-	HTMLComment           = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->"
-	ProcessingInstruction = "[<][?].*?[?][>]"
-	Declaration           = "<![A-Z]+" + "\\s+[^>]*>"
-	CDATA                 = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>"
-	HTMLTag               = "(?:" + OpenTag + "|" + CloseTag + "|" + HTMLComment + "|" +
-		ProcessingInstruction + "|" + Declaration + "|" + CDATA + ")"
+const (
+	tagName               = "[A-Za-z][A-Za-z0-9-]*"
+	attributeName         = "[a-zA-Z_:][a-zA-Z0-9:._-]*"
+	unquotedValue         = "[^\"'=<>`\\x00-\\x20]+"
+	singleQuotedValue     = "'[^']*'"
+	doubleQuotedValue     = "\"[^\"]*\""
+	attributeValue        = "(?:" + unquotedValue + "|" + singleQuotedValue + "|" + doubleQuotedValue + ")"
+	attributeValueSpec    = "(?:" + "\\s*=" + "\\s*" + attributeValue + ")"
+	attribute             = "(?:" + "\\s+" + attributeName + attributeValueSpec + "?)"
+	openTag               = "<" + tagName + attribute + "*" + "\\s*/?>"
+	closeTag              = "</" + tagName + "\\s*[>]"
+	htmlComment           = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->"
+	processingInstruction = "[<][?].*?[?][>]"
+	declaration           = "<![A-Z]+" + "\\s+[^>]*>"
+	cdata                 = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>"
+	htmlTag               = "(?:" + openTag + "|" + closeTag + "|" + htmlComment + "|" +
+		processingInstruction + "|" + declaration + "|" + cdata + ")"
 )
 
 var (
-	htmlTagRe = regexp.MustCompile("(?i)^" + HTMLTag)
+	htmlTagRe = regexp.MustCompile("(?i)^" + htmlTag)
 )
 
 // HTMLRendererParameters is a collection of supplementary parameters tweaking


### PR DESCRIPTION
They were cluttering the documentation and are not useful otherwise.