### PR TITLE
Add Smartypants support for French Guillemets

### DIFF
--- a/html.go
+++ b/html.go
@@ -44,6 +44,7 @@ const (
 	SmartypantsDashes                             // Enable smart dashes (with Smartypants)
 	SmartypantsLatexDashes                        // Enable LaTeX-style dashes (with Smartypants)
 	SmartypantsAngledQuotes                       // Enable angled double quotes (with Smartypants) for double quotes rendering
+	SmartypantsQuotesNBSP                         // Enable « French guillemets » (with Smartypants)
 	TOC                                           // Generate a table of contents
 
 	TagName               = "[A-Za-z][A-Za-z0-9-]*"

--- a/inline_test.go
+++ b/inline_test.go
@@ -1034,6 +1034,18 @@ func TestSmartDoubleQuotes(t *testing.T) {
 	doTestsInlineParam(t, tests, TestParams{HTMLFlags: Smartypants})
 }
 
+func TestSmartDoubleQuotesNBSP(t *testing.T) {
+	var tests = []string{
+		"this should be normal \"quoted\" text.\n",
+		"<p>this should be normal &ldquo;&nbsp;quoted&nbsp;&rdquo; text.</p>\n",
+		"this \" single double\n",
+		"<p>this &ldquo;&nbsp; single double</p>\n",
+		"two pair of \"some\" quoted \"text\".\n",
+		"<p>two pair of &ldquo;&nbsp;some&nbsp;&rdquo; quoted &ldquo;&nbsp;text&nbsp;&rdquo;.</p>\n"}
+
+	doTestsInlineParam(t, tests, TestParams{HTMLFlags: Smartypants | SmartypantsQuotesNBSP})
+}
+
 func TestSmartAngledDoubleQuotes(t *testing.T) {
 	var tests = []string{
 		"this should be angled \"quoted\" text.\n",
@@ -1044,6 +1056,18 @@ func TestSmartAngledDoubleQuotes(t *testing.T) {
 		"<p>two pair of &laquo;some&raquo; quoted &laquo;text&raquo;.</p>\n"}
 
 	doTestsInlineParam(t, tests, TestParams{HTMLFlags: Smartypants | SmartypantsAngledQuotes})
+}
+
+func TestSmartAngledDoubleQuotesNBSP(t *testing.T) {
+	var tests = []string{
+		"this should be angled \"quoted\" text.\n",
+		"<p>this should be angled &laquo;&nbsp;quoted&nbsp;&raquo; text.</p>\n",
+		"this \" single double\n",
+		"<p>this &laquo;&nbsp; single double</p>\n",
+		"two pair of \"some\" quoted \"text\".\n",
+		"<p>two pair of &laquo;&nbsp;some&nbsp;&raquo; quoted &laquo;&nbsp;text&nbsp;&raquo;.</p>\n"}
+
+	doTestsInlineParam(t, tests, TestParams{HTMLFlags: Smartypants | SmartypantsAngledQuotes | SmartypantsQuotesNBSP})
 }
 
 func TestSmartFractions(t *testing.T) {
@@ -1139,4 +1163,14 @@ func TestSkipHTML(t *testing.T) {
 		"text <em>inline html</em> more text",
 		"<p>text inline html more text</p>\n",
 	}, TestParams{HTMLFlags: SkipHTML})
+}
+
+func BenchmarkSmartDoubleQuotes(b *testing.B) {
+	params := TestParams{HTMLFlags: Smartypants}
+	params.extensions |= Autolink | Strikethrough
+	params.HTMLFlags |= UseXHTML
+
+	for i := 0; i < b.N; i++ {
+		runMarkdown("this should be normal \"quoted\" text.\n", params)
+	}
 }


### PR DESCRIPTION
This is a port of the fix for #378 in v1.

There is a slight alloc hit in the `SPRenderer` create, and I'm currently not seeing a smart way to avoid that.

```
name                 old time/op    new time/op    delta
EscapeHTML-4           1.22µs ± 2%    1.21µs ± 1%     ~     (p=0.222 n=5+5)
SmartDoubleQuotes-4    5.42µs ± 1%    5.56µs ± 1%   +2.76%  (p=0.008 n=5+5)
Reference-4            1.22ms ± 1%    1.21ms ± 2%     ~     (p=0.056 n=5+5)

name                 old alloc/op   new alloc/op   delta
EscapeHTML-4            0.00B          0.00B          ~     (all equal)
SmartDoubleQuotes-4    9.65kB ± 0%    9.87kB ± 0%   +2.32%  (p=0.008 n=5+5)
Reference-4            1.15MB ± 0%    1.15MB ± 0%   +0.43%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
EscapeHTML-4             0.00           0.00          ~     (all equal)
SmartDoubleQuotes-4      50.0 ± 0%      56.0 ± 0%  +12.00%  (p=0.008 n=5+5)
Reference-4             4.27k ± 0%     4.40k ± 0%   +3.09%  (p=0.008 n=5+5)
```

Fixes #380 