### PR TITLE
Allow EXTENSION_HEADER_IDS {#id} also in alternative headers syntax.

### DIFF
--- a/block.go
+++ b/block.go
@@ -1352,6 +1352,20 @@ func (p *parser) paragraph(out *bytes.Buffer, data []byte) int {
 					eol--
 				}
 
+				id := ""
+				if p.flags&EXTENSION_HEADER_IDS != 0 && eol > prev + 2 && data[eol-1] == '}' {
+					for j := eol - 2; j > prev; j-- {
+						if data[j] == '#' && data[j-1] == '{' {
+							id = string(data[j+1:eol-1])
+							eol = j - 1
+							for eol > prev && (data[eol-1] == ' ' || data[eol-1] == '\t') {
+								eol--
+							}
+							break
+						}
+					}
+				}
+
 				// render the header
 				// this ugly double closure avoids forcing variables onto the heap
 				work := func(o *bytes.Buffer, pp *parser, d []byte) func() bool {
@@ -1361,8 +1375,7 @@ func (p *parser) paragraph(out *bytes.Buffer, data []byte) int {
 					}
 				}(out, p, data[prev:eol])
 
-				id := ""
-				if p.flags&EXTENSION_AUTO_HEADER_IDS != 0 {
+				if id == "" && p.flags&EXTENSION_AUTO_HEADER_IDS != 0 {
 					id = SanitizedAnchorName(string(data[prev:eol]))
 				}
 


### PR DESCRIPTION
```
Header text   {#id}
-------------------
```