### PR TITLE
Added EmptyLink support for "[](meta data goes)"

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -527,7 +527,9 @@ func link(p *Markdown, data []byte, offset int) (int, *Node) {
 
 		// links need something to click on and somewhere to go
 		if len(uLink) == 0 || (t == linkNormal && txtE <= 1) {
-			return 0, nil
+                        if txtE == 1 && p.extensions&EmptyLink == 0 {
+                                return 0, nil
+                        }
 		}
 	}
 

--- a/markdown.go
+++ b/markdown.go
@@ -47,13 +47,14 @@ const (
 	AutoHeadingIDs                                // Create the heading ID from the text
 	BackslashLineBreak                            // Translate trailing backslashes into line breaks
 	DefinitionLists                               // Render definition lists
+        EmptyLink                                     // Parse empty links
 
 	CommonHTMLFlags HTMLFlags = UseXHTML | Smartypants |
 		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |
-		BackslashLineBreak | DefinitionLists
+		BackslashLineBreak | DefinitionLists | EmptyLink
 )
 
 // ListType contains bitwise or'ed flags for list and list item objects.


### PR DESCRIPTION
Please see https://github.com/russross/blackfriday/pull/401 for comments.
