### PR TITLE
Fix Windows-style newlines

### DIFF
--- a/block.go
+++ b/block.go
@@ -126,7 +126,7 @@ func (p *Markdown) block(data []byte) {
 		if p.isHRule(data) {
 			p.addBlock(HorizontalRule, nil)
 			var i int
-			for i = 0; i < len(data) && data[i] != '\n'; i++ {
+			for i = 0; i < len(data) && !iseol(data[i]); i++ {
 			}
 			data = data[i:]
 			continue
@@ -227,7 +227,7 @@ func (p *Markdown) prefixHeading(data []byte) int {
 		level++
 	}
 	i := skipChar(data, level, ' ')
-	end := skipUntilChar(data, i, '\n')
+	end := skipUntilNewline(data, i)
 	skip := end
 	id := ""
 	if p.extensions&HeadingIDs != 0 {
@@ -272,22 +272,20 @@ func (p *Markdown) isUnderlinedHeading(data []byte) int {
 	if data[0] == '=' {
 		i := skipChar(data, 1, '=')
 		i = skipChar(data, i, ' ')
-		if i < len(data) && data[i] == '\n' {
+		if i < len(data) && iseol(data[i]) {
 			return 1
 		}
 		return 0
 	}
-
 	// test of level 2 heading
 	if data[0] == '-' {
 		i := skipChar(data, 1, '-')
 		i = skipChar(data, i, ' ')
-		if i < len(data) && data[i] == '\n' {
+		if i < len(data) && iseol(data[i]) {
 			return 2
 		}
 		return 0
 	}
-
 	return 0
 }
 
@@ -299,7 +297,7 @@ func (p *Markdown) titleBlock(data []byte, doRender bool) int {
 	var i int
 	for idx, b := range splitData {
 		if !bytes.HasPrefix(b, []byte("%")) {
-			i = idx // - 1
+			i = idx
 			break
 		}
 	}
@@ -403,13 +401,9 @@ func (p *Markdown) html(data []byte, doRender bool) int {
 	// the end of the block has been found
 	if doRender {
 		// trim newlines
-		end := i
-		for end > 0 && data[end-1] == '\n' {
-			end--
-		}
+		end := trimTrailingNewlines(data, i)
 		finalizeHTMLBlock(p.addBlock(HTMLBlock, data[:end]))
 	}
-
 	return i
 }
 
@@ -426,10 +420,7 @@ func (p *Markdown) htmlComment(data []byte, doRender bool) int {
 		size := i + j
 		if doRender {
 			// trim trailing newlines
-			end := size
-			for end > 0 && data[end-1] == '\n' {
-				end--
-			}
+			end := trimTrailingNewlines(data, size)
 			block := p.addBlock(HTMLBlock, data[:end])
 			finalizeHTMLBlock(block)
 		}
@@ -451,7 +442,7 @@ func (p *Markdown) htmlHr(data []byte, doRender bool) int {
 		return 0
 	}
 	i := 3
-	for i < len(data) && data[i] != '>' && data[i] != '\n' {
+	for i < len(data) && data[i] != '>' && data[i] != '\n' && data[i] != '\r' {
 		i++
 	}
 	if i < len(data) && data[i] == '>' {
@@ -460,10 +451,7 @@ func (p *Markdown) htmlHr(data []byte, doRender bool) int {
 			size := i + j
 			if doRender {
 				// trim newlines
-				end := size
-				for end > 0 && data[end-1] == '\n' {
-					end--
-				}
+				end := trimTrailingNewlines(data, size)
 				finalizeHTMLBlock(p.addBlock(HTMLBlock, data[:end]))
 			}
 			return size
@@ -526,12 +514,12 @@ func (*Markdown) isEmpty(data []byte) int {
 	}
 
 	var i int
-	for i = 0; i < len(data) && data[i] != '\n'; i++ {
+	for i = 0; i < len(data) && !iseol(data[i]); i++ {
 		if data[i] != ' ' && data[i] != '\t' {
 			return 0
 		}
 	}
-	if i < len(data) && data[i] == '\n' {
+	if i < len(data) && iseol(data[i]) {
 		i++
 	}
 	return i
@@ -553,7 +541,7 @@ func (*Markdown) isHRule(data []byte) bool {
 
 	// the whole line must be the char or whitespace
 	n := 0
-	for i < len(data) && data[i] != '\n' {
+	for i < len(data) && !iseol(data[i]) {
 		switch {
 		case data[i] == c:
 			n++
@@ -623,7 +611,7 @@ func isFenceLine(data []byte, syntax *string, oldmarker string) (end int, marker
 			i++
 			syntaxStart++
 
-			for i < len(data) && data[i] != '}' && data[i] != '\n' {
+			for i < len(data) && data[i] != '}' && data[i] != '\n' && data[i] != '\r' {
 				syn++
 				i++
 			}
@@ -655,7 +643,7 @@ func isFenceLine(data []byte, syntax *string, oldmarker string) (end int, marker
 	}
 
 	i = skipChar(data, i, ' ')
-	if i >= len(data) || data[i] != '\n' {
+	if i >= len(data) || !iseol(data[i]) {
 		if i == len(data) {
 			return i, marker
 		}
@@ -689,7 +677,7 @@ func (p *Markdown) fencedCodeBlock(data []byte, doRender bool) int {
 		}
 
 		// copy the current line
-		end := skipUntilChar(data, beg, '\n') + 1
+		end := skipUntilNewline(data, beg) + 1
 
 		// did we reach the end of the buffer without a closing marker?
 		if end >= len(data) {
@@ -728,10 +716,10 @@ func unescapeString(str []byte) []byte {
 
 func finalizeCodeBlock(block *Node) {
 	if block.IsFenced {
-		newlinePos := bytes.IndexByte(block.content, '\n')
+		newlinePos := bytes.IndexByte(block.content, '\n') // XXX: \r
 		firstLine := block.content[:newlinePos]
 		rest := block.content[newlinePos+1:]
-		block.Info = unescapeString(bytes.Trim(firstLine, "\n"))
+		block.Info = unescapeString(bytes.Trim(firstLine, "\n")) // XXX: \r
 		block.Literal = rest
 	} else {
 		block.Literal = block.content
@@ -752,7 +740,7 @@ func (p *Markdown) table(data []byte) int {
 
 	for i < len(data) {
 		pipes, rowStart := 0, i
-		for ; i < len(data) && data[i] != '\n'; i++ {
+		for ; i < len(data) && !iseol(data[i]); i++ {
 			if data[i] == '|' {
 				pipes++
 			}
@@ -764,7 +752,7 @@ func (p *Markdown) table(data []byte) int {
 		}
 
 		// include the newline in data sent to tableRow
-		if i < len(data) && data[i] == '\n' {
+		if i < len(data) && iseol(data[i]) {
 			i++
 		}
 		p.tableRow(data[rowStart:i], columns, false)
@@ -785,7 +773,7 @@ func isBackslashEscaped(data []byte, i int) bool {
 func (p *Markdown) tableHeader(data []byte) (size int, columns []CellAlignFlags) {
 	i := 0
 	colCount := 1
-	for i = 0; i < len(data) && data[i] != '\n'; i++ {
+	for i = 0; i < len(data) && !iseol(data[i]); i++ {
 		if data[i] == '|' && !isBackslashEscaped(data, i) {
 			colCount++
 		}
@@ -798,7 +786,7 @@ func (p *Markdown) tableHeader(data []byte) (size int, columns []CellAlignFlags)
 
 	// include the newline in the data sent to tableRow
 	j := i
-	if j < len(data) && data[j] == '\n' {
+	if j < len(data) && iseol(data[j]) {
 		j++
 	}
 	header := data[:j]
@@ -827,7 +815,7 @@ func (p *Markdown) tableHeader(data []byte) (size int, columns []CellAlignFlags)
 	// each column header is of form: / *:?-+:? *|/ with # dashes + # colons >= 3
 	// and trailing | optional on last column
 	col := 0
-	for i < len(data) && data[i] != '\n' {
+	for i < len(data) && !iseol(data[i]) {
 		dashes := 0
 
 		if data[i] == ':' {
@@ -865,7 +853,7 @@ func (p *Markdown) tableHeader(data []byte) (size int, columns []CellAlignFlags)
 			}
 
 			// trailing junk found after last column
-			if col >= colCount && i < len(data) && data[i] != '\n' {
+			if col >= colCount && i < len(data) && !iseol(data[i]) {
 				return
 			}
 
@@ -873,7 +861,7 @@ func (p *Markdown) tableHeader(data []byte) (size int, columns []CellAlignFlags)
 			// something else found where marker was required
 			return
 
-		case data[i] == '\n':
+		case iseol(data[i]):
 			// marker is optional for the last column
 			col++
 
@@ -889,7 +877,7 @@ func (p *Markdown) tableHeader(data []byte) (size int, columns []CellAlignFlags)
 	p.addBlock(TableHead, nil)
 	p.tableRow(header, columns, true)
 	size = i
-	if size < len(data) && data[size] == '\n' {
+	if size < len(data) && iseol(data[size]) {
 		size++
 	}
 	return
@@ -910,7 +898,7 @@ func (p *Markdown) tableRow(data []byte, columns []CellAlignFlags, header bool) 
 
 		cellStart := i
 
-		for i < len(data) && (data[i] != '|' || isBackslashEscaped(data, i)) && data[i] != '\n' {
+		for i < len(data) && (data[i] != '|' || isBackslashEscaped(data, i)) && !iseol(data[i]) {
 			i++
 		}
 
@@ -975,7 +963,7 @@ func (p *Markdown) quote(data []byte) int {
 		// Step over whole lines, collecting them. While doing that, check for
 		// fenced code and if one's found, incorporate it altogether,
 		// irregardless of any contents inside it
-		for end < len(data) && data[end] != '\n' {
+		for end < len(data) && !iseol(data[end]) {
 			if p.extensions&FencedCode != 0 {
 				if i := p.fencedCodeBlock(data[end:], false); i > 0 {
 					// -1 to compensate for the extra end++ after the loop:
@@ -985,7 +973,7 @@ func (p *Markdown) quote(data []byte) int {
 			}
 			end++
 		}
-		if end < len(data) && data[end] == '\n' {
+		if end < len(data) && iseol(data[end]) {
 			end++
 		}
 		if pre := p.quotePrefix(data[beg:]); pre > 0 {
@@ -1020,10 +1008,10 @@ func (p *Markdown) code(data []byte) int {
 	i := 0
 	for i < len(data) {
 		beg := i
-		for i < len(data) && data[i] != '\n' {
+		for i < len(data) && !iseol(data[i]) {
 			i++
 		}
-		if i < len(data) && data[i] == '\n' {
+		if i < len(data) && iseol(data[i]) {
 			i++
 		}
 
@@ -1046,10 +1034,7 @@ func (p *Markdown) code(data []byte) int {
 
 	// trim all the \n off the end of work
 	workbytes := work.Bytes()
-	eol := len(workbytes)
-	for eol > 0 && workbytes[eol-1] == '\n' {
-		eol--
-	}
+	eol := trimTrailingNewlines(workbytes, len(workbytes))
 	if eol != len(workbytes) {
 		work.Truncate(eol)
 	}
@@ -1232,7 +1217,7 @@ func (p *Markdown) listItem(data []byte, flags *ListType) int {
 
 	// find the end of the line
 	line := i
-	for i > 0 && i < len(data) && data[i-1] != '\n' {
+	for i > 0 && i < len(data) && !iseol(data[i-1]) {
 		i++
 	}
 
@@ -1252,7 +1237,7 @@ gatherlines:
 		i++
 
 		// find the end of this line
-		for i < len(data) && data[i-1] != '\n' {
+		for i < len(data) && !iseol(data[i-1]) {
 			i++
 		}
 
@@ -1318,10 +1303,10 @@ gatherlines:
 			if *flags&ListTypeDefinition != 0 && i < len(data)-1 {
 				// is the next item still a part of this list?
 				next := i
-				for next < len(data) && data[next] != '\n' {
+				for next < len(data) && !iseol(data[next]) {
 					next++
 				}
-				for next < len(data)-1 && data[next] == '\n' {
+				for next < len(data)-1 && iseol(data[next]) {
 					next++
 				}
 				if i < len(data)-1 && data[i] != ':' && data[next] != ':' {
@@ -1393,13 +1378,7 @@ func (p *Markdown) renderParagraph(data []byte) {
 	for data[beg] == ' ' {
 		beg++
 	}
-
-	end := len(data)
-	// trim trailing newline
-	if data[len(data)-1] == '\n' {
-		end--
-	}
-
+	end := trimTrailingNewlines(data, len(data))
 	// trim trailing spaces
 	for end > beg && data[end-1] == ' ' {
 		end--
@@ -1470,7 +1449,7 @@ func (p *Markdown) paragraph(data []byte) int {
 				block.HeadingID = id
 
 				// find the end of the underline
-				for i < len(data) && data[i] != '\n' {
+				for i < len(data) && !iseol(data[i]) {
 					i++
 				}
 				return i
@@ -1518,13 +1497,9 @@ func (p *Markdown) paragraph(data []byte) int {
 				return i
 			}
 		}
-
-		// otherwise, scan to the beginning of the next line
-		nl := bytes.IndexByte(data[i:], '\n')
-		if nl >= 0 {
-			i += nl + 1
-		} else {
-			i += len(data[i:])
+		i = skipUntilNewline(data, i) + 1
+		if i > len(data) {
+			i = len(data)
 		}
 	}
 
@@ -1538,6 +1513,24 @@ func skipChar(data []byte, start int, char byte) int {
 		i++
 	}
 	return i
+}
+
+func skipUntilNewline(text []byte, start int) int {
+	i := start
+	for i < len(text) && !iseol(text[i]) {
+		i++
+	}
+	if i+1 < len(text) && text[i] == '\r' && text[i+1] == '\n' {
+		i++
+	}
+	return i
+}
+
+func trimTrailingNewlines(data []byte, end int) int {
+	for end > 0 && (data[end-1] == '\n' || data[end-1] == '\r') {
+		end--
+	}
+	return end
 }
 
 func skipUntilChar(text []byte, start int, char byte) int {

--- a/block_test.go
+++ b/block_test.go
@@ -1466,8 +1466,17 @@ func TestTitleBlock_EXTENSION_TITLEBLOCK(t *testing.T) {
 		"<h1 class=\"title\">" +
 			"Some title\n" +
 			"Another title line\n" +
-			"Yep, more here too" +
-			"</h1>\n",
+			"Yep, more here too</h1>\n",
+
+		// XXX: titleBlock implementation does not do normalization and leaves
+		// CRs in the output. This is not ideal, but will work for now.
+		"% Some title\r\n" +
+			"% Another title line\r\n" +
+			"% Yep, more here too\r\n",
+		"<h1 class=\"title\">" +
+			"Some title\r\n" +
+			"Another title line\r\n" +
+			"Yep, more here too</h1>\n",
 	}
 	doTestsBlock(t, tests, Titleblock)
 }

--- a/inline.go
+++ b/inline.go
@@ -60,7 +60,7 @@ func (p *Markdown) inline(currBlock *Node, data []byte) {
 		}
 	}
 	if beg < len(data) {
-		if data[end-1] == '\n' {
+		if iseol(data[end-1]) {
 			end--
 		}
 		currBlock.AppendChild(text(data[beg:end]))
@@ -166,8 +166,7 @@ func maybeLineBreak(p *Markdown, data []byte, offset int) (int, *Node) {
 	for offset < len(data) && data[offset] == ' ' {
 		offset++
 	}
-
-	if offset < len(data) && data[offset] == '\n' {
+	if offset < len(data) && iseol(data[offset]) {
 		if offset-origOffset >= 2 {
 			return offset - origOffset + 1, NewNode(Hardbreak)
 		}
@@ -261,7 +260,7 @@ func link(p *Markdown, data []byte, offset int) (int, *Node) {
 	// look for the matching closing bracket
 	for level := 1; level > 0 && i < len(data); i++ {
 		switch {
-		case data[i] == '\n':
+		case iseol(data[i]):
 			textHasNl = true
 
 		case data[i-1] == '\\':
@@ -408,7 +407,7 @@ func link(p *Markdown, data []byte, offset int) (int, *Node) {
 
 				for j := 1; j < txtE; j++ {
 					switch {
-					case data[j] != '\n':
+					case !iseol(data[j]):
 						b.WriteByte(data[j])
 					case data[j-1] != ' ':
 						b.WriteByte(' ')
@@ -448,7 +447,7 @@ func link(p *Markdown, data []byte, offset int) (int, *Node) {
 
 			for j := 1; j < txtE; j++ {
 				switch {
-				case data[j] != '\n':
+				case !iseol(data[j]):
 					b.WriteByte(data[j])
 				case data[j-1] != ' ':
 					b.WriteByte(' ')
@@ -650,7 +649,7 @@ func escape(p *Markdown, data []byte, offset int) (int, *Node) {
 	data = data[offset:]
 
 	if len(data) > 1 {
-		if p.extensions&BackslashLineBreak != 0 && data[1] == '\n' {
+		if p.extensions&BackslashLineBreak != 0 && iseol(data[1]) {
 			return 2, NewNode(Hardbreak)
 		}
 		if bytes.IndexByte(escapeChars, data[1]) < 0 {
@@ -854,7 +853,7 @@ func autoLink(p *Markdown, data []byte, offset int) (int, *Node) {
 		 *              => foo http://www.pokemon.com/Pikachu_(Electric)
 		 */
 
-		for bufEnd >= 0 && origData[bufEnd] != '\n' && openDelim != 0 {
+		for bufEnd >= 0 && !iseol(origData[bufEnd]) && openDelim != 0 {
 			if origData[bufEnd] == data[linkEnd-1] {
 				openDelim++
 			}
@@ -1066,7 +1065,7 @@ func helperFindEmphChar(data []byte, c byte) int {
 				i++
 			}
 			i++
-			for i < len(data) && (data[i] == ' ' || data[i] == '\n') {
+			for i < len(data) && (data[i] == ' ' || iseol(data[i])) {
 				i++
 			}
 			if i >= len(data) {

--- a/inline_test.go
+++ b/inline_test.go
@@ -1140,3 +1140,17 @@ func TestSkipHTML(t *testing.T) {
 		"<p>text inline html more text</p>\n",
 	}, TestParams{HTMLFlags: SkipHTML})
 }
+
+func TestWindowsNewlines(t *testing.T) {
+	var tests = []string{
+		"over *two\r\nlines* test\n",
+		"<p>over <em>two\r\nlines</em> test</p>\n",
+
+		"\r\nfoo\r\n*bar*\r\n",
+		"<p>foo\r\n<em>bar</em></p>\n",
+
+		"# Hello World\r\n\r\nThis is my content.\r\n",
+		"<h1>Hello World</h1>\n\n<p>This is my content.</p>\n",
+	}
+	doTestsInline(t, tests)
+}

--- a/markdown.go
+++ b/markdown.go
@@ -569,7 +569,7 @@ func isReference(p *Markdown, data []byte, tabSize int) int {
 		}
 	}
 	idOffset := i
-	for i < len(data) && data[i] != '\n' && data[i] != '\r' && data[i] != ']' {
+	for i < len(data) && !iseol(data[i]) && data[i] != ']' {
 		i++
 	}
 	if i >= len(data) || data[i] != ']' {
@@ -590,7 +590,7 @@ func isReference(p *Markdown, data []byte, tabSize int) int {
 	for i < len(data) && (data[i] == ' ' || data[i] == '\t') {
 		i++
 	}
-	if i < len(data) && (data[i] == '\n' || data[i] == '\r') {
+	if i < len(data) && iseol(data[i]) {
 		i++
 		if i < len(data) && data[i] == '\n' && data[i-1] == '\r' {
 			i++
@@ -652,7 +652,7 @@ func scanLinkRef(p *Markdown, data []byte, i int) (linkOffset, linkEnd, titleOff
 		i++
 	}
 	linkOffset = i
-	for i < len(data) && data[i] != ' ' && data[i] != '\t' && data[i] != '\n' && data[i] != '\r' {
+	for i < len(data) && data[i] != ' ' && data[i] != '\t' && !iseol(data[i]) {
 		i++
 	}
 	linkEnd = i
@@ -670,7 +670,7 @@ func scanLinkRef(p *Markdown, data []byte, i int) (linkOffset, linkEnd, titleOff
 	}
 
 	// compute end-of-line
-	if i >= len(data) || data[i] == '\r' || data[i] == '\n' {
+	if i >= len(data) || iseol(data[i]) {
 		lineEnd = i
 	}
 	if i+1 < len(data) && data[i] == '\r' && data[i+1] == '\n' {
@@ -691,7 +691,7 @@ func scanLinkRef(p *Markdown, data []byte, i int) (linkOffset, linkEnd, titleOff
 		titleOffset = i
 
 		// look for EOL
-		for i < len(data) && data[i] != '\n' && data[i] != '\r' {
+		for i < len(data) && !iseol(data[i]) {
 			i++
 		}
 		if i+1 < len(data) && data[i] == '\n' && data[i+1] == '\r' {
@@ -734,7 +734,7 @@ func scanFootnote(p *Markdown, data []byte, i, indentSize int) (blockStart, bloc
 
 	// find the end of the line
 	blockEnd = i
-	for i < len(data) && data[i-1] != '\n' {
+	for i < len(data) && data[i-1] != '\n' { // XXX: \r?
 		i++
 	}
 
@@ -753,7 +753,7 @@ gatherLines:
 		i++
 
 		// find the end of this line
-		for i < len(data) && data[i-1] != '\n' {
+		for i < len(data) && data[i-1] != '\n' { // XXX: \r?
 			i++
 		}
 
@@ -785,7 +785,7 @@ gatherLines:
 		blockEnd = i
 	}
 
-	if data[blockEnd-1] != '\n' {
+	if data[blockEnd-1] != '\n' { // XXX: \r?
 		raw.WriteByte('\n')
 	}
 
@@ -809,6 +809,10 @@ func ispunct(c byte) bool {
 		}
 	}
 	return false
+}
+
+func iseol(c byte) bool {
+	return c == '\n' || c == '\r'
 }
 
 // Test if a character is a whitespace character.


### PR DESCRIPTION
There still are a few XXX markers where it's clear from the code that it should deal with \r, but I couldn't pin-point a test case to exercise it yet.

Also, I'm planning to add a test runner that will translate all the `\n`s to `\r\n`s and re-run the tests.