### PR TITLE
add NoopenerLinks

### DIFF
--- a/html.go
+++ b/html.go
@@ -35,6 +35,7 @@ const (
 	Safelink                                      // Only link to trusted protocols
 	NofollowLinks                                 // Only link with rel="nofollow"
 	NoreferrerLinks                               // Only link with rel="noreferrer"
+	NoopenerLinks                                 // Only link with rel="noopener"
 	HrefTargetBlank                               // Add a blank target
 	CompletePage                                  // Generate a complete HTML page
 	UseXHTML                                      // Generate XHTML output instead of HTML
@@ -281,6 +282,9 @@ func appendLinkAttrs(attrs []string, flags HTMLFlags, link []byte) []string {
 	}
 	if flags&NoreferrerLinks != 0 {
 		val = append(val, "noreferrer")
+	}
+	if flags&NoopenerLinks != 0 {
+		val = append(val, "noopener")
 	}
 	if flags&HrefTargetBlank != 0 {
 		attrs = append(attrs, "target=\"_blank\"")

--- a/inline_test.go
+++ b/inline_test.go
@@ -497,15 +497,26 @@ func TestRelAttrLink(t *testing.T) {
 		HTMLFlags: Safelink | NoreferrerLinks,
 	})
 
-	var nofollownoreferrerTests = []string{
+	var noopenerTests = []string{
 		"[foo](http://bar.com/foo/)\n",
-		"<p><a href=\"http://bar.com/foo/\" rel=\"nofollow noreferrer\">foo</a></p>\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"noopener\">foo</a></p>\n",
 
 		"[foo](/bar/)\n",
 		"<p><a href=\"/bar/\">foo</a></p>\n",
 	}
-	doTestsInlineParam(t, nofollownoreferrerTests, TestParams{
-		HTMLFlags: Safelink | NofollowLinks | NoreferrerLinks,
+	doTestsInlineParam(t, noopenerTests, TestParams{
+		HTMLFlags: Safelink | NoopenerLinks,
+	})
+
+	var nofollownoreferrernoopenerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"nofollow noreferrer noopener\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, nofollownoreferrernoopenerTests, TestParams{
+		HTMLFlags: Safelink | NofollowLinks | NoreferrerLinks | NoopenerLinks,
 	})
 }
 


### PR DESCRIPTION
I think it is necessary to force rel="noopener" into the external links, even if there are other libraries such as bluemonday can do it.
The reason, blackfriday can formatting and displaying untrusted user data, but if the data is confirmed safe, it's unnecessary to sanitize data with bluemonday, and we still need to add rel="noopener" to keep site safe.
rel="noopener" is not about data, it's about **site** safe and **the style of links**. or, in other words, force rel="noopener" into the external links is the same as force target="_blank".
Why we discriminate "noopener"? Just because it is related to safe?