### PR TITLE
Fix consecutive lists of different kinds

### DIFF
--- a/block.go
+++ b/block.go
@@ -1291,8 +1291,24 @@ gatherlines:
 			}
 
 			// to be a nested list, it must be indented more
-			// if not, it is the next item in the same list
+			// if not, it is either a different kind of list
+			// or the next item in the same list
 			if indent <= itemIndent {
+				// are there different kinds of lists back-to-back?
+				var listTypeChanged bool
+				if p.dliPrefix(chunk) > 0 && *flags&ListTypeDefinition == 0 {
+					listTypeChanged = true
+				} else if p.oliPrefix(chunk) > 0 && *flags&ListTypeOrdered == 0 {
+					listTypeChanged = true
+				} else if p.uliPrefix(chunk) > 0 && (*flags&ListTypeOrdered != 0 || *flags&ListTypeDefinition != 0) {
+					listTypeChanged = true
+				}
+
+				if listTypeChanged {
+					*flags |= ListItemEndOfList
+					*flags &= ^ListItemContainsBlock
+				}
+
 				break gatherlines
 			}
 

--- a/block.go
+++ b/block.go
@@ -1148,6 +1148,18 @@ func (p *Markdown) list(data []byte, flags ListType) int {
 	return i
 }
 
+// Returns true if the list item is not the same type as its parent list
+func (p *Markdown) listTypeChanged(data []byte, flags *ListType) bool {
+	if p.dliPrefix(data) > 0 && *flags&ListTypeDefinition == 0 {
+		return true
+	} else if p.oliPrefix(data) > 0 && *flags&ListTypeOrdered == 0 {
+		return true
+	} else if p.uliPrefix(data) > 0 && (*flags&ListTypeOrdered != 0 || *flags&ListTypeDefinition != 0) {
+		return true
+	}
+	return false
+}
+
 // Returns true if block ends with a blank line, descending if needed
 // into lists and sublists.
 func endsWithBlankLine(block *Node) bool {
@@ -1286,30 +1298,21 @@ gatherlines:
 			p.oliPrefix(chunk) > 0 ||
 			p.dliPrefix(chunk) > 0:
 
-			if containsBlankLine {
-				*flags |= ListItemContainsBlock
-			}
-
 			// to be a nested list, it must be indented more
 			// if not, it is either a different kind of list
 			// or the next item in the same list
 			if indent <= itemIndent {
-				// are there different kinds of lists back-to-back?
-				var listTypeChanged bool
-				if p.dliPrefix(chunk) > 0 && *flags&ListTypeDefinition == 0 {
-					listTypeChanged = true
-				} else if p.oliPrefix(chunk) > 0 && *flags&ListTypeOrdered == 0 {
-					listTypeChanged = true
-				} else if p.uliPrefix(chunk) > 0 && (*flags&ListTypeOrdered != 0 || *flags&ListTypeDefinition != 0) {
-					listTypeChanged = true
-				}
-
-				if listTypeChanged {
+				if p.listTypeChanged(chunk, flags) {
 					*flags |= ListItemEndOfList
-					*flags &= ^ListItemContainsBlock
+				} else if containsBlankLine {
+					*flags |= ListItemContainsBlock
 				}
 
 				break gatherlines
+			}
+
+			if containsBlankLine {
+				*flags |= ListItemContainsBlock
 			}
 
 			// is this the first item in the nested list?

--- a/block_test.go
+++ b/block_test.go
@@ -853,6 +853,17 @@ func TestDefinitionList(t *testing.T) {
 	doTestsBlock(t, tests, DefinitionLists)
 }
 
+func TestConsecutiveLists(t *testing.T) {
+	var tests = []string{
+		"1. Hello\n\n* Hello\n\nTerm 1\n:   Definition a\n",
+		"<ol>\n<li>Hello</li>\n</ol>\n\n<ul>\n<li>Hello</li>\n</ul>\n\n<dl>\n<dt>Term 1</dt>\n<dd>Definition a</dd>\n</dl>\n",
+
+		"1. Not nested\n2. ordered list\n\n\t1. nested\n\t2. ordered list\n\n\t* nested\n\t* unordered list\n* Not nested\n* unordered list",
+		"<ol>\n<li>Not nested</li>\n<li>ordered list\n\n<ol>\n<li>nested</li>\n<li>ordered list</li>\n</ol>\n\n\n<ul>\n<li>nested</li>\n<li>unordered list</li>\n</ul></li>\n</ol>\n\n<ul>\n<li>Not nested</li>\n<li>unordered list</li>\n</ul>\n",
+	}
+	doTestsBlock(t, tests, DefinitionLists)
+}
+
 func TestPreformattedHtml(t *testing.T) {
 	var tests = []string{
 		"<div></div>\n",

--- a/block_test.go
+++ b/block_test.go
@@ -859,7 +859,7 @@ func TestConsecutiveLists(t *testing.T) {
 		"<ol>\n<li>Hello</li>\n</ol>\n\n<ul>\n<li>Hello</li>\n</ul>\n\n<dl>\n<dt>Term 1</dt>\n<dd>Definition a</dd>\n</dl>\n",
 
 		"1. Not nested\n2. ordered list\n\n\t1. nested\n\t2. ordered list\n\n\t* nested\n\t* unordered list\n* Not nested\n* unordered list",
-		"<ol>\n<li>Not nested</li>\n<li>ordered list\n\n<ol>\n<li>nested</li>\n<li>ordered list</li>\n</ol>\n\n\n<ul>\n<li>nested</li>\n<li>unordered list</li>\n</ul></li>\n</ol>\n\n<ul>\n<li>Not nested</li>\n<li>unordered list</li>\n</ul>\n",
+		"<ol>\n<li><p>Not nested</p></li>\n\n<li><p>ordered list</p>\n\n<ol>\n<li>nested</li>\n<li>ordered list</li>\n</ol>\n\n<ul>\n<li>nested</li>\n<li>unordered list</li>\n</ul></li>\n</ol>\n\n<ul>\n<li>Not nested</li>\n<li>unordered list</li>\n</ul>\n",
 	}
 	doTestsBlock(t, tests, DefinitionLists)
 }


### PR DESCRIPTION
```
1. hello
2. world

* goodbye
* world
```

now produces two lists:

1. hello
2. world

* goodbye
* world

instead of:

1. hello
2. world
3. goodbye
4. world