### PR TITLE
Add a reference for confluence wiki renderer in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ implements the following extensions:
 
         Cat
         : Fluffy animal everyone likes
-        
+
         Internet
         : Vector of transmission for pictures of cats
 
@@ -209,7 +209,7 @@ implements the following extensions:
     end of the document. A footnote looks like this:
 
         This is a footnote.[^1]
-        
+
         [^1]: the footnote text.
 
 *   **Autolinking**. Blackfriday can find URLs that have not been
@@ -257,6 +257,8 @@ are a few of note:
 
 *   [LaTeX output](https://github.com/Ambrevar/Blackfriday-LaTeX):
     renders output as LaTeX.
+
+*   [Blackfriday-Confluence](https://github.com/kentaro-m/blackfriday-confluence): provides a [Confluence Wiki Markup](https://confluence.atlassian.com/doc/confluence-wiki-markup-251003035.html) renderer.
 
 
 Todo


### PR DESCRIPTION
I created confluence wiki renderer for the Blackfriday v2. It would be great if you can add this renderer to README.md.