### PR TITLE
Accept info strings in code fences

### DIFF
--- a/block.go
+++ b/block.go
@@ -15,6 +15,7 @@ package blackfriday
 
 import (
 	"bytes"
+	"strings"
 	"unicode"
 )
 
@@ -92,7 +93,7 @@ func (p *parser) block(out *bytes.Buffer, data []byte) {
 
 		// fenced code block:
 		//
-		// ``` go
+		// ``` go info string here
 		// func fact(n int) int {
 		//     if n <= 1 {
 		//         return n
@@ -562,7 +563,7 @@ func (*parser) isHRule(data []byte) bool {
 // and returns the end index if so, or 0 otherwise. It also returns the marker found.
 // If syntax is not nil, it gets set to the syntax specified in the fence line.
 // A final newline is mandatory to recognize the fence line, unless newlineOptional is true.
-func isFenceLine(data []byte, syntax *string, oldmarker string, newlineOptional bool) (end int, marker string) {
+func isFenceLine(data []byte, info *string, oldmarker string, newlineOptional bool) (end int, marker string) {
 	i, size := 0, 0
 
 	// skip up to three spaces
@@ -598,9 +599,9 @@ func isFenceLine(data []byte, syntax *string, oldmarker string, newlineOptional 
 	}
 
 	// TODO(shurcooL): It's probably a good idea to simplify the 2 code paths here
-	// into one, always get the syntax, and discard it if the caller doesn't care.
-	if syntax != nil {
-		syn := 0
+	// into one, always get the info string, and discard it if the caller doesn't care.
+	if info != nil {
+		infoLength := 0
 		i = skipChar(data, i, ' ')
 
 		if i >= len(data) {
@@ -610,14 +611,14 @@ func isFenceLine(data []byte, syntax *string, oldmarker string, newlineOptional 
 			return 0, ""
 		}
 
-		syntaxStart := i
+		infoStart := i
 
 		if data[i] == '{' {
 			i++
-			syntaxStart++
+			infoStart++
 
 			for i < len(data) && data[i] != '}' && data[i] != '\n' {
-				syn++
+				infoLength++
 				i++
 			}
 
@@ -627,24 +628,24 @@ func isFenceLine(data []byte, syntax *string, oldmarker string, newlineOptional 
 
 			// strip all whitespace at the beginning and the end
 			// of the {} block
-			for syn > 0 && isspace(data[syntaxStart]) {
-				syntaxStart++
-				syn--
+			for infoLength > 0 && isspace(data[infoStart]) {
+				infoStart++
+				infoLength--
 			}
 
-			for syn > 0 && isspace(data[syntaxStart+syn-1]) {
-				syn--
+			for infoLength > 0 && isspace(data[infoStart+infoLength-1]) {
+				infoLength--
 			}
 
 			i++
 		} else {
-			for i < len(data) && !isspace(data[i]) {
-				syn++
+			for i < len(data) && !isverticalspace(data[i]) {
+				infoLength++
 				i++
 			}
 		}
 
-		*syntax = string(data[syntaxStart : syntaxStart+syn])
+		*info = strings.TrimSpace(string(data[infoStart : infoStart+infoLength]))
 	}
 
 	i = skipChar(data, i, ' ')
@@ -662,8 +663,8 @@ func isFenceLine(data []byte, syntax *string, oldmarker string, newlineOptional 
 // or 0 otherwise. It writes to out if doRender is true, otherwise it has no side effects.
 // If doRender is true, a final newline is mandatory to recognize the fenced code block.
 func (p *parser) fencedCodeBlock(out *bytes.Buffer, data []byte, doRender bool) int {
-	var syntax string
-	beg, marker := isFenceLine(data, &syntax, "", false)
+	var infoString string
+	beg, marker := isFenceLine(data, &infoString, "", false)
 	if beg == 0 || beg >= len(data) {
 		return 0
 	}
@@ -697,7 +698,7 @@ func (p *parser) fencedCodeBlock(out *bytes.Buffer, data []byte, doRender bool) 
 	}
 
 	if doRender {
-		p.r.BlockCode(out, work.Bytes(), syntax)
+		p.r.BlockCode(out, work.Bytes(), infoString)
 	}
 
 	return beg

--- a/block_test.go
+++ b/block_test.go
@@ -1652,11 +1652,11 @@ func TestCDATA(t *testing.T) {
 func TestIsFenceLine(t *testing.T) {
 	tests := []struct {
 		data            []byte
-		infoRequested bool
+		infoRequested   bool
 		newlineOptional bool
 		wantEnd         int
 		wantMarker      string
-		wantInfo      string
+		wantInfo        string
 	}{
 		{
 			data:    []byte("```"),
@@ -1668,10 +1668,10 @@ func TestIsFenceLine(t *testing.T) {
 			wantMarker: "```",
 		},
 		{
-			data:            []byte("```\nstuff here\n"),
+			data:          []byte("```\nstuff here\n"),
 			infoRequested: true,
-			wantEnd:         4,
-			wantMarker:      "```",
+			wantEnd:       4,
+			wantMarker:    "```",
 		},
 		{
 			data:    []byte("stuff here\n```\n"),
@@ -1685,34 +1685,34 @@ func TestIsFenceLine(t *testing.T) {
 		},
 		{
 			data:            []byte("```"),
-			infoRequested: true,
+			infoRequested:   true,
 			newlineOptional: true,
 			wantEnd:         3,
 			wantMarker:      "```",
 		},
 		{
 			data:            []byte("``` go"),
-			infoRequested: true,
+			infoRequested:   true,
 			newlineOptional: true,
 			wantEnd:         6,
 			wantMarker:      "```",
-			wantInfo:      "go",
+			wantInfo:        "go",
 		},
 		{
 			data:            []byte("``` go foo bar"),
-			infoRequested: true,
+			infoRequested:   true,
 			newlineOptional: true,
 			wantEnd:         14,
 			wantMarker:      "```",
-			wantInfo:      "go foo bar",
+			wantInfo:        "go foo bar",
 		},
 		{
 			data:            []byte("``` go foo bar  "),
-			infoRequested: true,
+			infoRequested:   true,
 			newlineOptional: true,
 			wantEnd:         16,
 			wantMarker:      "```",
-			wantInfo:      "go foo bar",
+			wantInfo:        "go foo bar",
 		},
 	}
 

--- a/block_test.go
+++ b/block_test.go
@@ -1053,6 +1053,9 @@ func TestFencedCodeBlock(t *testing.T) {
 		"``` go\nfunc foo() bool {\n\treturn true;\n}\n```\n",
 		"<pre><code class=\"language-go\">func foo() bool {\n\treturn true;\n}\n</code></pre>\n",
 
+		"``` go foo bar\nfunc foo() bool {\n\treturn true;\n}\n```\n",
+		"<pre><code class=\"language-go\">func foo() bool {\n\treturn true;\n}\n</code></pre>\n",
+
 		"``` c\n/* special & char < > \" escaping */\n```\n",
 		"<pre><code class=\"language-c\">/* special &amp; char &lt; &gt; &quot; escaping */\n</code></pre>\n",
 
@@ -1512,7 +1515,7 @@ func TestFencedCodeBlock_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK(t *testing.T) {
 		"<pre><code class=\"language-go\">func foo() bool {\n\treturn true;\n}\n</code></pre>\n",
 
 		"``` go foo bar\nfunc foo() bool {\n\treturn true;\n}\n```\n",
-		"<pre><code class=\"language-go foo bar\">func foo() bool {\n\treturn true;\n}\n</code></pre>\n",
+		"<pre><code class=\"language-go\">func foo() bool {\n\treturn true;\n}\n</code></pre>\n",
 
 		"``` c\n/* special & char < > \" escaping */\n```\n",
 		"<pre><code class=\"language-c\">/* special &amp; char &lt; &gt; &quot; escaping */\n</code></pre>\n",

--- a/html.go
+++ b/html.go
@@ -255,12 +255,12 @@ func (options *Html) HRule(out *bytes.Buffer) {
 	out.WriteByte('\n')
 }
 
-func (options *Html) BlockCode(out *bytes.Buffer, text []byte, lang string) {
+func (options *Html) BlockCode(out *bytes.Buffer, text []byte, info string) {
 	doubleSpace(out)
 
 	// parse out the language names/classes
 	count := 0
-	for _, elt := range strings.Fields(lang) {
+	for _, elt := range strings.Fields(info) {
 		if elt[0] == '.' {
 			elt = elt[1:]
 		}

--- a/html.go
+++ b/html.go
@@ -258,30 +258,18 @@ func (options *Html) HRule(out *bytes.Buffer) {
 func (options *Html) BlockCode(out *bytes.Buffer, text []byte, info string) {
 	doubleSpace(out)
 
-	// parse out the language names/classes
-	count := 0
-	for _, elt := range strings.Fields(info) {
-		if elt[0] == '.' {
-			elt = elt[1:]
-		}
-		if len(elt) == 0 {
-			continue
-		}
-		if count == 0 {
-			out.WriteString("<pre><code class=\"language-")
-		} else {
-			out.WriteByte(' ')
-		}
-		attrEscape(out, []byte(elt))
-		count++
+	endOfLang := strings.IndexAny(info, "\t ")
+	if endOfLang < 0 {
+		endOfLang = len(info)
 	}
-
-	if count == 0 {
+	lang := info[:endOfLang]
+	if len(lang) == 0 || lang == "." {
 		out.WriteString("<pre><code>")
 	} else {
+		out.WriteString("<pre><code class=\"language-")
+		attrEscape(out, []byte(lang))
 		out.WriteString("\">")
 	}
-
 	attrEscape(out, text)
 	out.WriteString("</code></pre>\n")
 }

--- a/latex.go
+++ b/latex.go
@@ -17,6 +17,7 @@ package blackfriday
 
 import (
 	"bytes"
+	"strings"
 )
 
 // Latex is a type that implements the Renderer interface for LaTeX output.
@@ -39,16 +40,17 @@ func (options *Latex) GetFlags() int {
 }
 
 // render code chunks using verbatim, or listings if we have a language
-func (options *Latex) BlockCode(out *bytes.Buffer, text []byte, lang string) {
-	if lang == "" {
+func (options *Latex) BlockCode(out *bytes.Buffer, text []byte, info string) {
+	if info == "" {
 		out.WriteString("\n\\begin{verbatim}\n")
 	} else {
+		lang := strings.Fields(info)[0]
 		out.WriteString("\n\\begin{lstlisting}[language=")
 		out.WriteString(lang)
 		out.WriteString("]\n")
 	}
 	out.Write(text)
-	if lang == "" {
+	if info == "" {
 		out.WriteString("\n\\end{verbatim}\n")
 	} else {
 		out.WriteString("\n\\end{lstlisting}\n")

--- a/markdown.go
+++ b/markdown.go
@@ -159,7 +159,7 @@ var blockTags = map[string]struct{}{
 // Currently Html and Latex implementations are provided
 type Renderer interface {
 	// block-level callbacks
-	BlockCode(out *bytes.Buffer, text []byte, lang string)
+	BlockCode(out *bytes.Buffer, text []byte, infoString string)
 	BlockQuote(out *bytes.Buffer, text []byte)
 	BlockHtml(out *bytes.Buffer, text []byte)
 	Header(out *bytes.Buffer, text func() bool, level int, id string)
@@ -804,7 +804,17 @@ func ispunct(c byte) bool {
 
 // Test if a character is a whitespace character.
 func isspace(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
+	return ishorizontalspace(c) || isverticalspace(c)
+}
+
+// Test if a character is a horizontal whitespace character.
+func ishorizontalspace(c byte) bool {
+	return c == ' ' || c == '\t'
+}
+
+// Test if a character is a vertical whitespace character.
+func isverticalspace(c byte) bool {
+	return c == '\n' || c == '\r' || c == '\f' || c == '\v'
 }
 
 // Test if a character is letter.


### PR DESCRIPTION
According to the common mark standard, code fence info strings can be anything,
not just single words. Update the tests and parser accordingly.

The formatter already expected an info string with a language and HTML classes,
so this does not need to change. Update the LaTeX formatter to take the first
word of the info string as the language.

Fixes #410 (in v1).