### PR TITLE
Added ability to manipulate HTML-attributes with AST

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -1,0 +1,87 @@
+package blackfriday
+
+import "strings"
+
+// Attr - Abstraction for html attribute
+type Attr []string
+
+// Add - adds one more attribute value
+func (a Attr) Add(value string) Attr {
+	return append(a, value)
+}
+
+// Remove - removes given value from attribute
+func (a Attr) Remove(value string) Attr {
+	for i := range a {
+		if a[i] == value {
+			return append(a[:i], a[i+1:]...)
+		}
+	}
+	return a
+}
+
+func (a Attr) String() string {
+	return strings.Join(a, " ")
+}
+
+// Attributes - store for many attributes
+type Attributes struct {
+	attrsMap map[string]Attr
+	keys     []string
+}
+
+// NewAttributes - creates new Attributes instance
+func NewAttributes() *Attributes {
+	return &Attributes{
+		attrsMap: make(map[string]Attr),
+	}
+}
+
+// Add - adds attribute if not exists and sets value for it
+func (a *Attributes) Add(name, value string) *Attributes {
+	if _, ok := a.attrsMap[name]; !ok {
+		a.attrsMap[name] = make(Attr, 0)
+		a.keys = append(a.keys, name)
+	}
+
+	a.attrsMap[name] = a.attrsMap[name].Add(value)
+	return a
+}
+
+// Remove - removes attribute by name
+func (a *Attributes) Remove(name string) *Attributes {
+	for i := range a.keys {
+		if a.keys[i] == name {
+			a.keys = append(a.keys[:i], a.keys[i+1:]...)
+		}
+	}
+
+	delete(a.attrsMap, name)
+	return a
+}
+
+// RemoveValue - removes given value from attribute by name
+// If given attribues become empty it alose removes entire attribute
+func (a *Attributes) RemoveValue(name, value string) *Attributes {
+	if attr, ok := a.attrsMap[name]; ok {
+		a.attrsMap[name] = attr.Remove(value)
+		if len(a.attrsMap[name]) == 0 {
+			a.Remove(name)
+		}
+	}
+	return a
+}
+
+// Empty - checks if attributes is empty
+func (a *Attributes) Empty() bool {
+	return len(a.keys) == 0
+}
+
+func (a *Attributes) String() string {
+	r := []string{}
+	for _, attrName := range a.keys {
+		r = append(r, attrName+"=\""+a.attrsMap[attrName].String()+"\"")
+	}
+
+	return strings.Join(r, " ")
+}

--- a/attributes.go
+++ b/attributes.go
@@ -2,16 +2,16 @@ package blackfriday
 
 import "strings"
 
-// Attr - Abstraction for html attribute
-type Attr []string
+// attr - Abstraction for html attribute
+type attr []string
 
 // Add - adds one more attribute value
-func (a Attr) Add(value string) Attr {
+func (a attr) add(value string) attr {
 	return append(a, value)
 }
 
 // Remove - removes given value from attribute
-func (a Attr) Remove(value string) Attr {
+func (a attr) remove(value string) attr {
 	for i := range a {
 		if a[i] == value {
 			return append(a[:i], a[i+1:]...)
@@ -20,31 +20,31 @@ func (a Attr) Remove(value string) Attr {
 	return a
 }
 
-func (a Attr) String() string {
+func (a attr) String() string {
 	return strings.Join(a, " ")
 }
 
 // Attributes - store for many attributes
 type Attributes struct {
-	attrsMap map[string]Attr
+	attrsMap map[string]attr
 	keys     []string
 }
 
 // NewAttributes - creates new Attributes instance
 func NewAttributes() *Attributes {
 	return &Attributes{
-		attrsMap: make(map[string]Attr),
+		attrsMap: make(map[string]attr),
 	}
 }
 
 // Add - adds attribute if not exists and sets value for it
 func (a *Attributes) Add(name, value string) *Attributes {
 	if _, ok := a.attrsMap[name]; !ok {
-		a.attrsMap[name] = make(Attr, 0)
+		a.attrsMap[name] = make(attr, 0)
 		a.keys = append(a.keys, name)
 	}
 
-	a.attrsMap[name] = a.attrsMap[name].Add(value)
+	a.attrsMap[name] = a.attrsMap[name].add(value)
 	return a
 }
 
@@ -64,7 +64,7 @@ func (a *Attributes) Remove(name string) *Attributes {
 // If given attribues become empty it alose removes entire attribute
 func (a *Attributes) RemoveValue(name, value string) *Attributes {
 	if attr, ok := a.attrsMap[name]; ok {
-		a.attrsMap[name] = attr.Remove(value)
+		a.attrsMap[name] = attr.remove(value)
 		if len(a.attrsMap[name]) == 0 {
 			a.Remove(name)
 		}

--- a/attributes.go
+++ b/attributes.go
@@ -7,6 +7,11 @@ type attr []string
 
 // Add - adds one more attribute value
 func (a attr) add(value string) attr {
+	for _, item := range a {
+		if item == value {
+			return a
+		}
+	}
 	return append(a, value)
 }
 

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -1,0 +1,86 @@
+package blackfriday
+
+import "testing"
+
+func TestEmtyAttributes(t *testing.T) {
+	a := NewAttributes()
+	r := a.String()
+	e := ""
+	if r != e {
+		t.Errorf("Emmpty attributes must return empty string\nExpected: %s\nActual: %s", e, r)
+	}
+}
+
+func TestAddOneAttribute(t *testing.T) {
+	a := NewAttributes()
+	a.Add("class", "wrapper")
+	if s := a.String(); s != "class=\"wrapper\"" {
+		t.Errorf("Unexprected output: %s", s)
+	}
+}
+
+func TestAddFewValuesToOneAttribute(t *testing.T) {
+	a := NewAttributes()
+	a.Add("class", "wrapper").Add("class", "-with-image")
+	if s := a.String(); s != "class=\"wrapper -with-image\"" {
+		t.Errorf("Unexpected output: %s", s)
+	}
+}
+
+func TestRemoveValueFromOneAttribute(t *testing.T) {
+	a := NewAttributes()
+	a.Add("class", "wrapper").Add("class", "-with-image")
+	if s := a.String(); s != "class=\"wrapper -with-image\"" {
+		t.Errorf("Unexpected output: %s", s)
+	}
+	a.RemoveValue("class", "wrapper")
+	if s := a.String(); s != "class=\"-with-image\"" {
+		t.Errorf("Unexpected output: %s", s)
+	}
+}
+
+func TestRemoveWholeAttribute(t *testing.T) {
+	a := NewAttributes()
+	a.Add("class", "wrapper")
+	if s := a.String(); s != "class=\"wrapper\"" {
+		t.Errorf("Unexprected output: %s", s)
+	}
+	a.Remove("class")
+	if a.String() != "" {
+		t.Errorf("Emmpty attributes must return empty string")
+	}
+}
+
+func TestRemoveWholeAttributeByValue(t *testing.T) {
+	a := NewAttributes()
+	a.Add("class", "wrapper")
+	if s := a.String(); s != "class=\"wrapper\"" {
+		t.Errorf("Unexprected output: %s", s)
+	}
+	a.RemoveValue("class", "wrapper")
+	r := a.String()
+	e := ""
+	if r != e {
+		t.Errorf("Emmpty attributes must return empty string\nExpected: %s\nActual: %s", e, r)
+	}
+}
+
+func TestAddFewAttributes(t *testing.T) {
+	a := NewAttributes()
+	a.Add("class", "wrapper").Add("id", "main-block")
+	if s := a.String(); s != "class=\"wrapper\" id=\"main-block\"" {
+		t.Errorf("Unexprected output: %s", s)
+	}
+}
+
+func TestAddComplexAttributes(t *testing.T) {
+	a := NewAttributes()
+	a.
+		Add("style", "background: #fff;").
+		Add("style", "font-size: 14px;").
+		Add("data-test-id", "block")
+	e := "style=\"background: #fff; font-size: 14px;\" data-test-id=\"block\""
+	if s := a.String(); s != e {
+		t.Errorf("Unexpected output: %s", s)
+	}
+}

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -34,6 +34,16 @@ func TestAddFewValuesToOneAttribute(t *testing.T) {
 	}
 }
 
+func TestAddSameValueToAttribute(t *testing.T) {
+	a := NewAttributes()
+	a.Add("class", "wrapper").Add("class", "wrapper")
+	r := a.String()
+	e := "class=\"wrapper\""
+	if r != e {
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
+	}
+}
+
 func TestRemoveValueFromOneAttribute(t *testing.T) {
 	a := NewAttributes()
 	a.Add("class", "wrapper").Add("class", "-with-image")

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -7,69 +7,70 @@ func TestEmtyAttributes(t *testing.T) {
 	r := a.String()
 	e := ""
 	if r != e {
-		t.Errorf("Emmpty attributes must return empty string\nExpected: %s\nActual: %s", e, r)
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }
 
 func TestAddOneAttribute(t *testing.T) {
 	a := NewAttributes()
 	a.Add("class", "wrapper")
-	if s := a.String(); s != "class=\"wrapper\"" {
-		t.Errorf("Unexprected output: %s", s)
+	r := a.String()
+	e := "class=\"wrapper\""
+	if r != e {
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }
 
 func TestAddFewValuesToOneAttribute(t *testing.T) {
 	a := NewAttributes()
 	a.Add("class", "wrapper").Add("class", "-with-image")
-	if s := a.String(); s != "class=\"wrapper -with-image\"" {
-		t.Errorf("Unexpected output: %s", s)
+	r := a.String()
+	e := "class=\"wrapper -with-image\""
+	if r != e {
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }
 
 func TestRemoveValueFromOneAttribute(t *testing.T) {
 	a := NewAttributes()
 	a.Add("class", "wrapper").Add("class", "-with-image")
-	if s := a.String(); s != "class=\"wrapper -with-image\"" {
-		t.Errorf("Unexpected output: %s", s)
-	}
 	a.RemoveValue("class", "wrapper")
-	if s := a.String(); s != "class=\"-with-image\"" {
-		t.Errorf("Unexpected output: %s", s)
+	r := a.String()
+	e := "class=\"-with-image\""
+	if r != e {
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }
 
 func TestRemoveWholeAttribute(t *testing.T) {
 	a := NewAttributes()
 	a.Add("class", "wrapper")
-	if s := a.String(); s != "class=\"wrapper\"" {
-		t.Errorf("Unexprected output: %s", s)
-	}
 	a.Remove("class")
-	if a.String() != "" {
-		t.Errorf("Emmpty attributes must return empty string")
+	r := a.String()
+	e := ""
+	if r != e {
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }
 
 func TestRemoveWholeAttributeByValue(t *testing.T) {
 	a := NewAttributes()
 	a.Add("class", "wrapper")
-	if s := a.String(); s != "class=\"wrapper\"" {
-		t.Errorf("Unexprected output: %s", s)
-	}
 	a.RemoveValue("class", "wrapper")
 	r := a.String()
 	e := ""
 	if r != e {
-		t.Errorf("Emmpty attributes must return empty string\nExpected: %s\nActual: %s", e, r)
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }
 
 func TestAddFewAttributes(t *testing.T) {
 	a := NewAttributes()
 	a.Add("class", "wrapper").Add("id", "main-block")
-	if s := a.String(); s != "class=\"wrapper\" id=\"main-block\"" {
-		t.Errorf("Unexprected output: %s", s)
+	r := a.String()
+	e := "class=\"wrapper\" id=\"main-block\""
+	if r != e {
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }
 
@@ -79,8 +80,9 @@ func TestAddComplexAttributes(t *testing.T) {
 		Add("style", "background: #fff;").
 		Add("style", "font-size: 14px;").
 		Add("data-test-id", "block")
+	r := a.String()
 	e := "style=\"background: #fff; font-size: 14px;\" data-test-id=\"block\""
-	if s := a.String(); s != e {
-		t.Errorf("Unexpected output: %s", s)
+	if r != e {
+		t.Errorf("Expected: %s\nActual: %s\n", e, r)
 	}
 }

--- a/node.go
+++ b/node.go
@@ -128,6 +128,8 @@ type Node struct {
 	LinkData      // Populated if Type is Link
 	TableCellData // Populated if Type is TableCell
 
+	Attributes *Attributes // Contains HTML-attributes for current node
+
 	content []byte // Markdown content of the block nodes
 	open    bool   // Specifies an open block node that has not been finished to process yet
 }
@@ -135,8 +137,9 @@ type Node struct {
 // NewNode allocates a node of a specified type.
 func NewNode(typ NodeType) *Node {
 	return &Node{
-		Type: typ,
-		open: true,
+		Type:       typ,
+		open:       true,
+		Attributes: NewAttributes(),
 	}
 }
 


### PR DESCRIPTION
**Purpose:** make possible to change output HTML attributes without re-implementing whole renderer.

For example, I want to add extra class to  paragraphs which contains images. Now I can do it simply analyzing and changing AST before rendering content:

``` go
func TestASTModification(t *testing.T) {
	input := "\nPicture signature\n![alt text](/p.jpg)\n"
	expected := "<p class=\"img\">Picture signature\n<img src=\"/p.jpg\" alt=\"alt text\" /></p>\n"

	r := NewHTMLRenderer(HTMLRendererParameters{
		Flags: CommonHTMLFlags,
	})
	var buf bytes.Buffer
	optList := []Option{
		WithRenderer(r),
		WithExtensions(CommonExtensions)}
	parser := New(optList...)
	ast := parser.Parse([]byte(input))
	r.RenderHeader(&buf, ast)
	ast.Walk(func(node *Node, entering bool) WalkStatus {
                // Where the magic happens
		if node.Type == Image && entering && node.Parent.Type == Paragraph {
			node.Parent.Attributes.Add("class", "img")
		}
		return GoToNext
	})
	ast.Walk(func(node *Node, entering bool) WalkStatus {
		return r.RenderNode(&buf, node, entering)
	})
	r.RenderFooter(&buf, ast)
	actual := buf.String()

	if actual != expected {
		t.Errorf("Expected: %s\nActual: %s\n", expected, actual)
	}
}
```