### PR TITLE
V2 fix deprecated alignment attribute

### DIFF
--- a/html.go
+++ b/html.go
@@ -786,7 +786,7 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 		if entering {
 			align := cellAlignment(node.Align)
 			if align != "" {
-				attrs = append(attrs, fmt.Sprintf(`align="%s"`, align))
+				attrs = append(attrs, fmt.Sprintf(`style="text-align: %s;"`, align))
 			}
 			if node.Prev == nil {
 				r.cr(w)


### PR DESCRIPTION
Attribute 'align' is deprecated in HTML5 for th and td (among others). Modified to use inline-CSS instead. Here is a better citation for the deprecation: https://www.w3.org/TR/2011/WD-html-markup-20110113/table.html