### PR TITLE
Fix checking of backslash in link text (#510)

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -278,7 +278,7 @@ func link(p *Markdown, data []byte, offset int) (int, *Node) {
 		case data[i] == '\n':
 			textHasNl = true
 
-		case data[i-1] == '\\':
+		case isBackslashEscaped(data, i):
 			continue
 
 		case data[i] == '[':

--- a/testdata/Links, inline style.html
+++ b/testdata/Links, inline style.html
@@ -8,4 +8,6 @@
 
 <p><a href="/url/" title="title has spaces afterward">URL and title</a>.</p>
 
+<p><a href="/url/">URL with backslash\</a>.</p>
+
 <p>[Empty]().</p>

--- a/testdata/Links, inline style.text
+++ b/testdata/Links, inline style.text
@@ -8,5 +8,6 @@ Just a [URL](/url/).
 
 [URL and title](/url/ "title has spaces afterward"  ).
 
+[URL with backslash\\](/url/).
 
 [Empty]().


### PR DESCRIPTION
Fix #510.

By using `isBackslashEscaped`, it prevents incorrect interpretation of backslash in link.