### PR TITLE
Remove dep on umaintained difflib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/russross/blackfriday/v2
-
-require github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -14,12 +14,12 @@
 package blackfriday
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
-
-	"github.com/pmezard/go-difflib/difflib"
 )
 
 type TestParams struct {
@@ -187,12 +187,22 @@ func doTestsReference(t *testing.T, files []string, flag Extensions) {
 }
 
 func doTestDiff(name, expected, actual string) string {
-	d, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(expected),
-		B:        difflib.SplitLines(actual),
-		FromFile: "expect: " + name,
-		ToFile:   "actual: " + name,
-		Context:  1,
-	})
+	expectedLines := strings.Split(expected, "\n")
+	actualLines := strings.Split(actual, "\n")
+	d := "file: " + name + "\n"
+	for i, line := range expectedLines {
+		// Allow the actualLines indexing to panic because we're in tests where
+		// that's okay and we probably want to know about it if this input is wrong
+		// somehow.
+		if line != actualLines[i] {
+			d += fmt.Sprintf(`
+line: %d
+
+-%s
++%s
+`, i, line, actualLines[i])
+		}
+	}
+
 	return d
 }


### PR DESCRIPTION
This removes the testing dependency on [`github.com/pmezard/go-difflib`](https://godoc.org/github.com/pmezard/go-difflib/difflib) which, per the [README](https://github.com/pmezard/go-difflib/blob/master/README.md), is no longer maintained.

I did not try to match the diff output exactly, assuming these weren't actual patches being applied somewhere, but the relevant information is still included.

A failing test now looks like this:

```
blackfriday (v2 *=) $ go test
--- FAIL: TestReference_EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK (8.09s)
    helpers_test.go:173:
        file: Amps and angle encoding

        line: 6

        -<p>4 &lt; 6.</p>
        +<p>4 &lt; 5.</p>

        line: 16

        -<p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a></p>
        +<p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>
--- FAIL: TestReference (7.16s)
    helpers_test.go:173:
        file: Amps and angle encoding

        line: 6

        -<p>4 &lt; 6.</p>
        +<p>4 &lt; 5.</p>

        line: 16

        -<p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a></p>
        +<p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>
FAIL
exit status 1
FAIL    github.com/russross/blackfriday/v2      8.318s
```