### PR TITLE
Export Node.IsContainer and add Node.IsLeaf

### DIFF
--- a/node.go
+++ b/node.go
@@ -199,7 +199,8 @@ func (n *Node) InsertBefore(sibling *Node) {
 	}
 }
 
-func (n *Node) isContainer() bool {
+// IsContainer returns true if 'n' can contain children.
+func (n *Node) IsContainer() bool {
 	switch n.Type {
 	case Document:
 		fallthrough
@@ -309,11 +310,11 @@ func newNodeWalker(root *Node) *nodeWalker {
 }
 
 func (nw *nodeWalker) next() {
-	if (!nw.current.isContainer() || !nw.entering) && nw.current == nw.root {
+	if (!nw.current.IsContainer() || !nw.entering) && nw.current == nw.root {
 		nw.current = nil
 		return
 	}
-	if nw.entering && nw.current.isContainer() {
+	if nw.entering && nw.current.IsContainer() {
 		if nw.current.FirstChild != nil {
 			nw.current = nw.current.FirstChild
 			nw.entering = true

--- a/node.go
+++ b/node.go
@@ -239,6 +239,11 @@ func (n *Node) IsContainer() bool {
 	}
 }
 
+// IsLeaf returns true if 'n' is a leaf node.
+func (n *Node) IsLeaf() bool {
+	return !n.IsContainer()
+}
+
 func (n *Node) canContain(t NodeType) bool {
 	if n.Type == List {
 		return t == Item


### PR DESCRIPTION
These functions are very useful for applications that walk the AST generated by `blackfriday`. Without these exports, the applications have to work out which are leaf nodes and which are container nodes themselves.