### PR TITLE
allow writing of user-specified <meta.../> tags to document header

### DIFF
--- a/html.go
+++ b/html.go
@@ -82,6 +82,13 @@ type Html struct {
 	title    string // document title
 	css      string // optional css file url (used with HTML_COMPLETE_PAGE)
 
+	// The optional 'meta' map holds additional meta tags to
+	//	place into the final document's header.
+	// Format:
+	//		key: name="author"
+	//		val: foo barrington
+	meta map[string]string
+
 	parameters HtmlRendererParameters
 
 	// table of contents data
@@ -130,6 +137,8 @@ func HtmlRendererWithParameters(flags int, title string,
 		title:      title,
 		css:        css,
 		parameters: renderParameters,
+
+		meta: make(map[string]string),
 
 		headerCount:  0,
 		currentLevel: 0,
@@ -685,6 +694,14 @@ func (options *Html) DocumentHeader(out *bytes.Buffer) {
 	out.WriteString("  <meta charset=\"utf-8\"")
 	out.WriteString(ending)
 	out.WriteString(">\n")
+	// plug the user-specified <meta.../> tags
+	if options.meta != nil {
+		for k, v := range options.meta {
+			out.WriteString("  <meta " + k + " content=\"" + v + "\"")
+			out.WriteString(ending)
+			out.WriteString(">\n")
+		}
+	}
 	if options.css != "" {
 		out.WriteString("  <link rel=\"stylesheet\" type=\"text/css\" href=\"")
 		attrEscape(out, []byte(options.css))


### PR DESCRIPTION
Added a field to the `Html` struct that holds a `map[string]string`. `HtmlRendererWithParameters()` then returns an `Html` struct with the map initialized. The user may then specify `<meta.../>` tags to be included in the document header when the document is parsed (and `HTML_COMPLETE_PAGE` is flagged).

To allow for the different types of meta tags, the map follows this format:
```
var meta = map[string]string{
  "name=\"author\"": "foo barrington",
  "http-equiv=\"refresh\"": "1; url=http://localhost",
}
```

With the key being the full attribute of `name="..."` or `http-equiv="..."`, and value being the unquoted value of the attribute `contents="..."`