### PR TITLE
Add AutoHeadingAnchorLinks extension

### DIFF
--- a/block.go
+++ b/block.go
@@ -260,9 +260,19 @@ func (p *Markdown) prefixHeading(data []byte) int {
 		if id == "" && p.extensions&AutoHeadingIDs != 0 {
 			id = SanitizedAnchorName(string(data[i:end]))
 		}
+
 		block := p.addBlock(Heading, data[i:end])
 		block.HeadingID = id
 		block.Level = level
+
+		if p.extensions&AutoHeadingAnchorLinks != 0 {
+			link := NewNode(Link)
+			link.Destination = []byte("#" + id)
+			linkText := NewNode(Text)
+			linkText.Literal = []byte("#")
+			link.AppendChild(linkText)
+			block.AppendChild(link)
+		}
 	}
 	return skip
 }

--- a/block_test.go
+++ b/block_test.go
@@ -1916,3 +1916,36 @@ func TestSanitizedAnchorName(t *testing.T) {
 		}
 	}
 }
+
+func TestPrefixHeaderAnchorLinksExtension(t *testing.T) {
+	t.Parallel()
+	var tests = []string{
+		"# Header 1\n",
+		"<h1 id=\"header-1\"><a href=\"#header-1\">#</a>Header 1</h1>\n",
+
+		"# Header 1   \n",
+		"<h1 id=\"header-1\"><a href=\"#header-1\">#</a>Header 1</h1>\n",
+
+		"## Header 2\n",
+		"<h2 id=\"header-2\"><a href=\"#header-2\">#</a>Header 2</h2>\n",
+
+		"### Header 3\n",
+		"<h3 id=\"header-3\"><a href=\"#header-3\">#</a>Header 3</h3>\n",
+
+		"#### Header 4\n",
+		"<h4 id=\"header-4\"><a href=\"#header-4\">#</a>Header 4</h4>\n",
+
+		"##### Header 5\n",
+		"<h5 id=\"header-5\"><a href=\"#header-5\">#</a>Header 5</h5>\n",
+
+		"###### Header 6\n",
+		"<h6 id=\"header-6\"><a href=\"#header-6\">#</a>Header 6</h6>\n",
+
+		"####### Header 7\n",
+		"<h6 id=\"header-7\"><a href=\"#header-7\">#</a># Header 7</h6>\n",
+
+		"Hello\n# Header 1\nGoodbye\n",
+		"<p>Hello</p>\n\n<h1 id=\"header-1\"><a href=\"#header-1\">#</a>Header 1</h1>\n\n<p>Goodbye</p>\n",
+	}
+	doTestsBlock(t, tests, AutoHeadingIDs|AutoHeadingAnchorLinks)
+}

--- a/markdown.go
+++ b/markdown.go
@@ -47,6 +47,7 @@ const (
 	AutoHeadingIDs                                // Create the heading ID from the text
 	BackslashLineBreak                            // Translate trailing backslashes into line breaks
 	DefinitionLists                               // Render definition lists
+	AutoHeadingAnchorLinks                        // Create anchor links for headings
 
 	CommonHTMLFlags HTMLFlags = UseXHTML | Smartypants |
 		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes


### PR DESCRIPTION
This PR adds an extension 'AutoHeadingAnchorLinks' that can be used to automatically add an anchor link to each header.

This is used to generate HTML similar to these examples:

- https://gohugo.io/getting-started/configuration/#configure-blackfriday
- https://github.com/russross/blackfriday/blob/master/README.md#installation (the link is only visible on hover on Github)
- https://css-tricks.com/css-content/#article-header-id-1

It's a pretty [common request for Hugo](https://discourse.gohugo.io/t/adding-anchor-next-to-headers/1726).  I'm personally looking to add this feature to my Hugo site as well.

It's possible to workaround the issue with JavaScript or regex but an extension is a little easier and should be less likely to fail.

When the `AutoHeadingAnchorLinks` and `AutoHeadingIDs` extensions are enabled this markdown:

```markdown
# First

Some text

## Second
```

...would create this HTML:

```html
<h1 id="first"><a href="#first">#</a>First</h1>

<p>Some text</p>

<h2 id="second"><a href="#second">#</a>Second</h2>
```

It's possible to enable just the `AutoHeadingAnchorLinks` extension without the `AutoHeadingIDs` or `HeadingIDs` extension, it just generates links like `<a href="#">#</a>`. Not that you would want to do that but it doesn't break anything 😁.

My only concern with this extension is it seems pretty common to want to use a SVG instead of `#` for the link. It _is_ possible to override this with CSS, i.e.

```css
h1 > a, h2 > a, h3 > a, h4 > a, h5 > a, h6 > a {
  visibility: hidden;
}

h1 > a:before, h2 > a:before, h3 > a:before, h4 > a:before, h5 > a:before, h6 > a:before {
  visibility: visible;
  content: '🔗';
}
```