### PR TITLE
Use ↩ as default params.FootnoteReturnLinkContents

### DIFF
--- a/html.go
+++ b/html.go
@@ -132,7 +132,10 @@ func NewHTMLRenderer(params HTMLRendererParameters) *HTMLRenderer {
 	}
 
 	if params.FootnoteReturnLinkContents == "" {
-		params.FootnoteReturnLinkContents = `<sup>[return]</sup>`
+		// U+FE0E is VARIATION SELECTOR-15.
+		// It suppresses automatic emoji presentation of the preceding
+		// U+21A9 LEFTWARDS ARROW WITH HOOK on iOS and iPadOS.
+		params.FootnoteReturnLinkContents = "<span aria-label='Return'>↩\ufe0e</span>"
 	}
 
 	return &HTMLRenderer{


### PR DESCRIPTION
This changes the default `params.FootnoteReturnLinkContents` from `<sup>[return]</sup>` to `<span aria-label='Return'>↩\ufe0e</span>`.

It’s very common to use `↩` in footnote links. However, some platforms like iOS and iPadOS choose to use emoji presentation for this particular character. This leads to lots of blogs, by default, looking silly on portable Apple gizmos, as described in <https://github.com/jgm/pandoc/issues/5469>. By switching to a return arrow with a disable-emojification variation selector, we get blackfriday to do the right thing by default.

Additionally, ↩ is more language-agnostic than “return” is, so blackfriday will work better out of the box for more people.