### PR TITLE
Implement a furigana extension

### DIFF
--- a/html.go
+++ b/html.go
@@ -492,6 +492,18 @@ func (options *Html) Emphasis(out *bytes.Buffer, text []byte) {
 	out.WriteString("</em>")
 }
 
+func (options *Html) Furigana(out *bytes.Buffer, kanji []byte, furigana []byte) {
+	if len(kanji) == 0 {
+		return
+	}
+	out.WriteString("<ruby lang=\"ja\"><rb>")
+	out.Write(kanji)
+	out.WriteString("</rb><rp>（</rp><rt>")
+	out.Write(furigana)
+	out.WriteString("</rt><rp>）</rp></ruby>")
+}
+
+
 func (options *Html) maybeWriteAbsolutePrefix(out *bytes.Buffer, link []byte) {
 	if options.parameters.AbsolutePrefix != "" && isRelativeLink(link) && link[0] != '.' {
 		out.WriteString(options.parameters.AbsolutePrefix)

--- a/inline_test.go
+++ b/inline_test.go
@@ -344,6 +344,29 @@ func TestEmphasisLink(t *testing.T) {
 	doTestsInline(t, tests)
 }
 
+func TestFurigana(t *testing.T) {
+	var tests = []string{
+		"（漢字）（かんじ）\n",
+		"<p><ruby lang=\"ja\"><rb>漢字</rb><rp>（</rp><rt>かんじ</rt><rp>）</rp></ruby></p>\n",
+
+		"漢字（かんじ）\n",
+		"<p><ruby lang=\"ja\"><rb>漢字</rb><rp>（</rp><rt>かんじ</rt><rp>）</rp></ruby></p>\n",
+
+		"Reading Japanese text is easier with （ふりがな）（furigana）\n",
+		"<p>Reading Japanese text is easier with <ruby lang=\"ja\"><rb>ふりがな</rb><rp>（</rp><rt>furigana</rt><rp>）</rp></ruby></p>\n",
+
+		"（）（）\n",
+		"<p>（）（）</p>\n",
+
+		"（すごい）ですね？\n",
+		"<p>（すごい）ですね？</p>\n",
+
+		"エリア（eria）\n",
+		"<p>エリア（eria）</p>\n",
+	}
+	doTestsInline(t, tests)
+}
+
 func TestStrikeThrough(t *testing.T) {
 	var tests = []string{
 		"nothing inline\n",

--- a/latex.go
+++ b/latex.go
@@ -213,6 +213,18 @@ func (options *Latex) Emphasis(out *bytes.Buffer, text []byte) {
 	out.WriteString("}")
 }
 
+func (options *Latex) Furigana(out *bytes.Buffer, kanji []byte, furigana []byte) {
+	if len(kanji) == 0 {
+		return
+	}
+	out.WriteString("<ruby><rb>")
+	out.Write(kanji)
+	out.WriteString("</rb><rp>（</rp><rt>")
+	out.Write(furigana)
+	out.WriteString("</rt><rp>）</rp></ruby>")
+}
+
+
 func (options *Latex) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {
 	if bytes.HasPrefix(link, []byte("http://")) || bytes.HasPrefix(link, []byte("https://")) {
 		// treat it like a link

--- a/markdown.go
+++ b/markdown.go
@@ -44,6 +44,7 @@ const (
 	EXTENSION_BACKSLASH_LINE_BREAK                   // translate trailing backslashes into line breaks
 	EXTENSION_DEFINITION_LISTS                       // render definition lists
 	EXTENSION_JOIN_LINES                             // delete newline and join lines
+	EXTENSION_FURIGANA                               // render furigana using html's <ruby> tag
 
 	commonHtmlFlags = 0 |
 		HTML_USE_XHTML |
@@ -61,7 +62,8 @@ const (
 		EXTENSION_SPACE_HEADERS |
 		EXTENSION_HEADER_IDS |
 		EXTENSION_BACKSLASH_LINE_BREAK |
-		EXTENSION_DEFINITION_LISTS
+		EXTENSION_DEFINITION_LISTS |
+		EXTENSION_FURIGANA
 )
 
 // These are the possible flag values for the link renderer.
@@ -180,6 +182,7 @@ type Renderer interface {
 	CodeSpan(out *bytes.Buffer, text []byte)
 	DoubleEmphasis(out *bytes.Buffer, text []byte)
 	Emphasis(out *bytes.Buffer, text []byte)
+	Furigana(out *bytes.Buffer, kanji []byte, furigana []byte)
 	Image(out *bytes.Buffer, link []byte, title []byte, alt []byte)
 	LineBreak(out *bytes.Buffer)
 	Link(out *bytes.Buffer, link []byte, title []byte, content []byte)
@@ -384,6 +387,12 @@ func MarkdownOptions(input []byte, renderer Renderer, opts Options) []byte {
 		p.notes = make([]*reference, 0)
 		p.notesRecord = make(map[string]struct{})
 	}
+
+	//if extensions&EXTENSION_FURIGANA != 0 {
+	for i := 128; i < 256; i++ {
+		p.inlineCallback[i] = handle_multi_byte_utf8
+	}
+	//}
 
 	first := firstPass(p, input)
 	second := secondPass(p, first)


### PR DESCRIPTION
Implement a furigana extension based on the syntax used in https://github.com/djfun/furigana_markdown. See https://discourse.gohugo.io/t/using-furigana-ruby-with-markdown/15156/4 to understand what this is for.

I made this some months ago and now I realized Hugo switched to goldmark, oh well...