### PR TITLE
Added an extension which allowes to parse links with empty link text.

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -538,9 +538,12 @@ func link(p *Markdown, data []byte, offset int) (int, *Node) {
 			unescapeText(&uLinkBuf, link)
 			uLink = uLinkBuf.Bytes()
 		}
-
-		// links need something to click on and somewhere to go
-		if len(uLink) == 0 || (t == linkNormal && txtE <= 1) {
+		// links need somewhere to go
+		if len(uLink) == 0 {
+			return 0, nil
+		}
+		// links usually need something to click on
+		if t == linkNormal && txtE <= 1 && p.extensions&AllowLinksWithoutText == 0 {
 			return 0, nil
 		}
 	}

--- a/inline_test.go
+++ b/inline_test.go
@@ -466,8 +466,19 @@ func TestInlineLink(t *testing.T) {
 
 		"[link](<../>)\n",
 		"<p><a href=\"../\">link</a></p>\n",
+
+		"[](./dummy.md)\n",
+		"<p>[](./dummy.md)</p>\n",
 	}
 	doLinkTestsInline(t, tests)
+
+	var testsAllowLinksWithoutText = []string{
+		"[](./dummy.md)\n",
+		"<p><a href=\"./dummy.md\"></a></p>\n",
+	}
+	doTestsInlineParam(t, testsAllowLinksWithoutText, TestParams{
+		extensions: AllowLinksWithoutText,
+	})
 
 }
 

--- a/markdown.go
+++ b/markdown.go
@@ -47,6 +47,7 @@ const (
 	AutoHeadingIDs                                // Create the heading ID from the text
 	BackslashLineBreak                            // Translate trailing backslashes into line breaks
 	DefinitionLists                               // Render definition lists
+	AllowLinksWithoutText                         // Parse links without text, (e.g. [](./target.md)
 
 	CommonHTMLFlags HTMLFlags = UseXHTML | Smartypants |
 		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes


### PR DESCRIPTION
Added an extension which allowes to parse links with empty link text.

This is related to: https://github.com/russross/blackfriday/pull/402

# Example

    [](./target.md)
    
# Use-Case
The tool I am working on can find and insert the first title of referenced documents. In this case the need of some link text or magic words would be curious. 

# Usage 
Enable the `AllowLinksWithoutText` extension. Without that flag blackfriday will behave like before.

# Note
The beheaviour of the extension is conform with CommonMark:
- [Specification](https://spec.commonmark.org/0.29/#link-text) 
- [Example](https://spec.commonmark.org/dingus/?text=%5B%5D(.%2Ftarget.md))


