### PR TITLE
go.mod: add go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/russross/blackfriday
+
+go 1.13


### PR DESCRIPTION
This is a result of running `go mod tidy` using go 1.13.6.

In my devel toolchain (vim-go -> gopls -> go 1.13), go apparently
wants to add this line to go.mod, but since the modules are read-only,
it fails, which leads to gopls failing, too.

Merging this and tagging a release would help tremendously
(not because of this PR per se, but mostly because of
https://github.com/russross/blackfriday/pull/509 and https://github.com/russross/blackfriday/pull/515 
which are not in a released version yet).

@russross @rtfb @SamWhited PTAL