### PR TITLE
Ignore underscore conditionally with the IgnoreUnderscore extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ implements the following extensions:
     becomes `<sup>4</sup>&frasl;<sub>5</sub>`, which renders as
     <sup>4</sup>&frasl;<sub>5</sub>.
 
+*   **Ignore Underscore** is similar to intra-word emphasis supression. However, 
+    it goes to the next level and ignores underscores completely. 
+    Underscores will not be processed, wherever they may occur.   
 
 Other renderers
 ---------------

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/russross/blackfriday/v2
+module github.com/dmitrytorba/blackfriday/v2

--- a/inline_test.go
+++ b/inline_test.go
@@ -1214,3 +1214,33 @@ func BenchmarkSmartDoubleQuotes(b *testing.B) {
 		runMarkdown("this should be normal \"quoted\" text.\n", params)
 	}
 }
+
+func TestIgnoreUnderscore(t *testing.T) {
+	t.Parallel()
+	var tests = []string{
+		"simple _inline_ test\n",
+		"<p>simple _inline_ test</p>\n",
+
+		"_at the_ beginning\n",
+		"<p>_at the_ beginning</p>\n",
+
+		"at the _end_\n",
+		"<p>at the _end_</p>\n",
+
+		"_try two_ in _one line_\n",
+		"<p>_try two_ in _one line_</p>\n",
+
+		"over _two\nlines_ test\n",
+		"<p>over _two\nlines_ test</p>\n",
+
+		"odd _number of_ markers_ here\n",
+		"<p>odd _number of_ markers_ here</p>\n",
+
+		"odd _number\nof_ markers_ here\n",
+		"<p>odd _number\nof_ markers_ here</p>\n",
+
+		"mix of *markers_\n",
+		"<p>mix of *markers_</p>\n",
+	}
+	doTestsInlineParam(t, tests, TestParams{extensions: IgnoreUnderscore})
+}

--- a/markdown.go
+++ b/markdown.go
@@ -47,6 +47,7 @@ const (
 	AutoHeadingIDs                                // Create the heading ID from the text
 	BackslashLineBreak                            // Translate trailing backslashes into line breaks
 	DefinitionLists                               // Render definition lists
+	IgnoreUnderscore                              // Ignore all underscores
 
 	CommonHTMLFlags HTMLFlags = UseXHTML | Smartypants |
 		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
@@ -285,7 +286,9 @@ func New(opts ...Option) *Markdown {
 	// register inline parsers
 	p.inlineCallback[' '] = maybeLineBreak
 	p.inlineCallback['*'] = emphasis
-	p.inlineCallback['_'] = emphasis
+	if p.extensions&IgnoreUnderscore == 0 {
+		p.inlineCallback['_'] = emphasis
+	}
 	if p.extensions&Strikethrough != 0 {
 		p.inlineCallback['~'] = emphasis
 	}


### PR DESCRIPTION
This PR adds an extension `IgnoreUnderscore` that can be used to skip processing all underscores. Similar to `NoIntraEmphasis` this extension can be used by users to control the rendering behavior of underscores.

BTW, thanks for the project! Its a very useful tool. 