### PR TITLE
Fix trailing <br>s added in lists with EXTENSION_HARD_LINE_BREAK enabled

### DIFF
--- a/block.go
+++ b/block.go
@@ -1305,9 +1305,29 @@ gatherlines:
 	cookedBytes := cooked.Bytes()
 	parsedEnd := len(cookedBytes)
 
-	// strip trailing newlines
-	for parsedEnd > 0 && cookedBytes[parsedEnd-1] == '\n' {
-		parsedEnd--
+	if p.flags&EXTENSION_HARD_LINE_BREAK != 0 {
+		// strip trailing newlines and extra hard line breaks
+		const brLen = len("<br />")
+		for parsedEnd > 0 &&
+			(cookedBytes[parsedEnd-1] == '\n' ||
+				(parsedEnd >= brLen &&
+					cookedBytes[parsedEnd-brLen] == '<' &&
+					cookedBytes[parsedEnd-brLen+1] == 'b' &&
+					cookedBytes[parsedEnd-brLen+2] == 'r' &&
+					cookedBytes[parsedEnd-brLen+3] == ' ' &&
+					cookedBytes[parsedEnd-brLen+4] == '/' &&
+					cookedBytes[parsedEnd-brLen+5] == '>')) {
+			if cookedBytes[parsedEnd-1] == '\n' {
+				parsedEnd--
+			} else {
+				parsedEnd -= brLen
+			}
+		}
+	} else {
+		// strip trailing newlines
+		for parsedEnd > 0 && cookedBytes[parsedEnd-1] == '\n' {
+			parsedEnd--
+		}
 	}
 	p.r.ListItem(out, cookedBytes[:parsedEnd], *flags)
 

--- a/block_test.go
+++ b/block_test.go
@@ -1636,6 +1636,51 @@ func TestListWithFencedCodeBlockNoExtensions(t *testing.T) {
 	doTestsBlock(t, tests, 0)
 }
 
+func TestListEXTENSION_HARD_LINE_BREAK(t *testing.T) {
+	// If there is a fenced code block in a list, and FencedCode is not set,
+	// lists should be processed normally.
+	var tests = []string{
+		`* One
+* Two
+
+Text`,
+		`<ul>
+<li>One</li>
+<li>Two</li>
+</ul>
+
+<p>Text</p>
+`,
+
+		`* Double
+line
+* Single line
+
+Text`,
+		`<ul>
+<li>Double<br />
+line</li>
+<li>Single line</li>
+</ul>
+
+<p>Text</p>
+`,
+
+		`1. One
+2. Two
+
+Text`,
+		`<ol>
+<li>One</li>
+<li>Two</li>
+</ol>
+
+<p>Text</p>
+`,
+	}
+	doTestsBlock(t, tests, EXTENSION_HARD_LINE_BREAK)
+}
+
 func TestTitleBlock_EXTENSION_TITLEBLOCK(t *testing.T) {
 	var tests = []string{
 		"% Some title\n" +


### PR DESCRIPTION
Previously, with `EXTENSION_HARD_LINE_BREAK` enabled, `<li>`s would contain unnecessary `<br />`s at the end of each item. It was especially noticeable by the vertical space this left following an ordered or unordered list.

This fixes that by also stripping trailing `<br />`s from individual list items when this extension is enabled.

One shortcoming of this patch: it does not completely fix the issue in *nested* lists, as far as the markup goes -- but the *visual* issues are gone, at least. I can work on fully fixing the markup if there's interest in that.

**Input**:

```
* One
* Two

Paragraph
```

<table>
<tr><th>Previous Result</th><th>Fixed Result</th></tr>
<tr valign="top"><td><pre>&lt;ul>
&lt;li>One&lt;br />&lt;/li>
&lt;li>Two&lt;br />
&lt;br />&lt;/li>
&lt;/ul>
&nbsp;
&lt;p>Paragraph&lt;/p></pre></td>

<td><pre>&lt;ul>
&lt;li>One&lt;/li>
&lt;li>Two&lt;/li>
&lt;/ul>
&nbsp;
&lt;p>Paragraph&lt;/p></pre></td>
</tr>
</table>