### PR TITLE
Added ability to disable smart parens, fixes #411,

### DIFF
--- a/html.go
+++ b/html.go
@@ -46,6 +46,7 @@ const (
 	SmartypantsLatexDashes                        // Enable LaTeX-style dashes (with Smartypants)
 	SmartypantsAngledQuotes                       // Enable angled double quotes (with Smartypants) for double quotes rendering
 	SmartypantsQuotesNBSP                         // Enable « French guillemets » (with Smartypants)
+	SmartypantsParens                             // Enable smart parens (with Smartypants)
 	TOC                                           // Generate a table of contents
 )
 

--- a/markdown.go
+++ b/markdown.go
@@ -49,7 +49,7 @@ const (
 	DefinitionLists                               // Render definition lists
 
 	CommonHTMLFlags HTMLFlags = UseXHTML | Smartypants |
-		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
+		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes | SmartypantsParens
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |

--- a/smartypants.go
+++ b/smartypants.go
@@ -411,7 +411,9 @@ func NewSmartypantsRenderer(flags HTMLFlags) *SPRenderer {
 		}
 	}
 	r.callbacks['\''] = r.smartSingleQuote
-	r.callbacks['('] = r.smartParens
+	if flags&SmartypantsParens != 0 {
+		r.callbacks['('] = r.smartParens
+	}
 	if flags&SmartypantsDashes != 0 {
 		if flags&SmartypantsLatexDashes == 0 {
 			r.callbacks['-'] = r.smartDash


### PR DESCRIPTION
You can now run the following code to disable smart parens:

```Go
mdOpt = blackfriday.WithRenderer(blackfriday.NewHTMLRenderer(blackfriday.HTMLRendererParameters{
  Flags: blackfriday.CommonHTMLFlags ^ blackfriday.SmartypantsParens,
}))

blackfriday.Run([]byte(...), mdOpt)
```