### PR TITLE
Fix panic parsing list definition

### DIFF
--- a/block.go
+++ b/block.go
@@ -1360,7 +1360,7 @@ gatherlines:
 			if *flags&ListTypeDefinition != 0 && i < len(data)-1 {
 				// is the next item still a part of this list?
 				next := i
-				for next < len(data) && data[next] != '\n' {
+				for next < len(data)-1 && data[next] != '\n' {
 					next++
 				}
 				for next < len(data)-1 && data[next] == '\n' {

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -34,6 +34,10 @@ func TestDocument(t *testing.T) {
 		// https://github.com/russross/blackfriday/issues/173
 		"   [",
 		"<p>[</p>\n",
+
+		// This should't panic.
+		"text\n\n:item: **text**\ntext\n",
+		"<dl>\n<dt>text</dt>\n</dl>\n\n<p>:item: <strong>text</strong>\ntext</p>\n",
 	}
 	doTests(t, tests)
 }


### PR DESCRIPTION
This file causes panic on parse:

https://raw.githubusercontent.com/carnot-technologies/redis-scaling/master/README.md

The panic:

```
panic: runtime error: index out of range [709] with length 709 [recovered]
	panic: runtime error: index out of range [709] with length 709

goroutine 18 [running]:
testing.tRunner.func1.2({0x52c000, 0xc0001fc000})
	/usr/lib/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1212 +0x218
panic({0x52c000, 0xc0001fc000})
	/usr/lib/go/src/runtime/panic.go:1038 +0x215
github.com/russross/blackfriday/v2.(*Markdown).listItem(0xc0001d0900, {0xc0001c3daa, 0x2c5, 0x0}, 0xc00009acd0)
	/home/jfontan/git/blackfriday/block.go:1372 +0xd9b
github.com/russross/blackfriday/v2.(*Markdown).list(0xc0001d0900, {0xc0001c3daa, 0x2c5, 0x2c6}, 0x16)
	/home/jfontan/git/blackfriday/block.go:1135 +0xdd
github.com/russross/blackfriday/v2.(*Markdown).paragraph(0xc0001d0900, {0xc0001c3d6e, 0x301, 0x302})
	/home/jfontan/git/blackfriday/block.go:1485 +0x525
github.com/russross/blackfriday/v2.(*Markdown).block(0xc0001d0900, {0xc0001c2000, 0x40cf47, 0x10})
	/home/jfontan/git/blackfriday/block.go:194 +0x671
github.com/russross/blackfriday/v2.(*Markdown).Parse(0xc0001d0900, {0xc0001c2000, 0x0, 0x0})
	/home/jfontan/git/blackfriday/markdown.go:404 +0x27
github.com/russross/blackfriday/v2.Run({0xc0001c2000, 0x206f, 0x2070}, {0x0, 0x0, 0x465cf3})
	/home/jfontan/git/blackfriday/markdown.go:388 +0x1f9
github.com/russross/blackfriday/v2.TestBadReadme(0xc000083380)
	/home/jfontan/git/blackfriday/badreadme_test.go:14 +0x98
testing.tRunner(0xc000083380, 0x5553d0)
	/usr/lib/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:1306 +0x35a
```

I've changed the code so the variable `next` is never larger or equal than `data` size. I'm not sure is the correct fix as it treats previous text to a definition list as a `dl`. At least it does not crash now.