### PR TITLE
bugfix: Resolve #701

### DIFF
--- a/block.go
+++ b/block.go
@@ -1296,7 +1296,7 @@ gatherlines:
 		if p.extensions&FencedCode != 0 {
 			// determine if in or out of codeblock
 			// if in codeblock, ignore normal list processing
-			_, marker := isFenceLine(chunk, nil, codeBlockMarker)
+			_, marker := isFenceLine(chunk, new(string), codeBlockMarker)
 			if marker != "" {
 				if codeBlockMarker == "" {
 					// start of codeblock


### PR DESCRIPTION
`isFenceLine` was being called within `listItem` for finding code blocks. It was unable to detect code blocks with an info string since a nil string pointer was being passed in. Now the pointer is not nil so info-string code blocks are correctly parsed within lists. Resolves #701 