### PR TITLE
fix cell alignment

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -1299,10 +1299,10 @@ func TestTable(t *testing.T) {
 			"<tbody>\n<tr>\n<td><em>d</em></td>\n<td><strong>e</strong></td>\n<td>f</td>\n</tr>\n</tbody>\n</table>\n",
 
 		"a|b|c|d\n:--|--:|:-:|---\ne|f|g|h\n",
-		"<table>\n<thead>\n<tr>\n<th align=\"left\">a</th>\n<th align=\"right\">b</th>\n" +
-			"<th align=\"center\">c</th>\n<th>d</th>\n</tr>\n</thead>\n\n" +
-			"<tbody>\n<tr>\n<td align=\"left\">e</td>\n<td align=\"right\">f</td>\n" +
-			"<td align=\"center\">g</td>\n<td>h</td>\n</tr>\n</tbody>\n</table>\n",
+		"<table>\n<thead>\n<tr>\n<th align=\"left\" style=\"text-align: left\">a</th>\n<th align=\"right\" style=\"text-align: right\">b</th>\n" +
+			"<th align=\"center\" style=\"text-align: center\">c</th>\n<th>d</th>\n</tr>\n</thead>\n\n" +
+			"<tbody>\n<tr>\n<td align=\"left\" style=\"text-align: left\">e</td>\n<td align=\"right\" style=\"text-align: right\">f</td>\n" +
+			"<td align=\"center\" style=\"text-align: center\">g</td>\n<td>h</td>\n</tr>\n</tbody>\n</table>\n",
 
 		"a|b|c\n---|---|---\n",
 		"<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th>c</th>\n</tr>\n</thead>\n\n<tbody>\n</tbody>\n</table>\n",

--- a/html.go
+++ b/html.go
@@ -302,11 +302,11 @@ func (options *Html) TableHeaderCell(out *bytes.Buffer, text []byte, align int) 
 	doubleSpace(out)
 	switch align {
 	case TABLE_ALIGNMENT_LEFT:
-		out.WriteString("<th align=\"left\">")
+		out.WriteString("<th align=\"left\" style=\"text-align: left\">")
 	case TABLE_ALIGNMENT_RIGHT:
-		out.WriteString("<th align=\"right\">")
+		out.WriteString("<th align=\"right\" style=\"text-align: right\">")
 	case TABLE_ALIGNMENT_CENTER:
-		out.WriteString("<th align=\"center\">")
+		out.WriteString("<th align=\"center\" style=\"text-align: center\">")
 	default:
 		out.WriteString("<th>")
 	}
@@ -319,11 +319,11 @@ func (options *Html) TableCell(out *bytes.Buffer, text []byte, align int) {
 	doubleSpace(out)
 	switch align {
 	case TABLE_ALIGNMENT_LEFT:
-		out.WriteString("<td align=\"left\">")
+		out.WriteString("<td align=\"left\" style=\"text-align: left\">")
 	case TABLE_ALIGNMENT_RIGHT:
-		out.WriteString("<td align=\"right\">")
+		out.WriteString("<td align=\"right\" style=\"text-align: right\">")
 	case TABLE_ALIGNMENT_CENTER:
-		out.WriteString("<td align=\"center\">")
+		out.WriteString("<td align=\"center\" style=\"text-align: center\">")
 	default:
 		out.WriteString("<td>")
 	}


### PR DESCRIPTION
According to https://www.w3schools.com/Css/css_table_align.asp and to my experience of using https://github.com/kovetskiy/mark, alignment of cells with blackfriday does not work correctly.

This patch fixes the issue by inserting `style="text-align: <alignment>"` into each `td` and `th`.