### PR TITLE
Feature: Allow adding custom styles to images

### DIFF
--- a/html.go
+++ b/html.go
@@ -72,6 +72,8 @@ type HtmlRendererParameters struct {
 	HeaderIDPrefix string
 	// If set, add this text to the back of each Header ID, to ensure uniqueness.
 	HeaderIDSuffix string
+	// If set, add this style to each image.
+	ImageStyleTag string
 }
 
 // Html is a type that implements the Renderer interface for HTML output.
@@ -520,6 +522,10 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 	if len(title) > 0 {
 		out.WriteString("\" title=\"")
 		attrEscape(out, title)
+	}
+	if options.parameters.ImageStyleTag != "" {
+		out.WriteString("\" style=\"")
+		attrEscape(out, []byte(options.parameters.ImageStyleTag))
 	}
 
 	out.WriteByte('"')


### PR DESCRIPTION
This PR adds a small but very useful feature: in our use case, we would like to limit the size of images so that the final HTML file can be exported as PDF and not be distorted by huge images. This can easily be achieved by adding a `style` tag to all images in the generated HTML data.

Not only that, but this would allow other styling changes to images, such as centering them, which could be useful for many users.