### PR TITLE
Add HTMLComment node type

### DIFF
--- a/block.go
+++ b/block.go
@@ -430,7 +430,7 @@ func (p *Markdown) htmlComment(data []byte, doRender bool) int {
 			for end > 0 && data[end-1] == '\n' {
 				end--
 			}
-			block := p.addBlock(HTMLBlock, data[:end])
+			block := p.addBlock(HTMLComment, data[:end])
 			finalizeHTMLBlock(block)
 		}
 		return size

--- a/html.go
+++ b/html.go
@@ -632,7 +632,7 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 			// to be added and when not.
 			if node.Prev != nil {
 				switch node.Prev.Type {
-				case HTMLBlock, List, Paragraph, Heading, CodeBlock, BlockQuote, HorizontalRule:
+				case HTMLBlock, HTMLComment, List, Paragraph, Heading, CodeBlock, BlockQuote, HorizontalRule:
 					r.cr(w)
 				}
 			}
@@ -654,7 +654,7 @@ func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkSt
 			r.out(w, blockquoteCloseTag)
 			r.cr(w)
 		}
-	case HTMLBlock:
+	case HTMLBlock, HTMLComment:
 		if r.Flags&SkipHTML != 0 {
 			break
 		}

--- a/node.go
+++ b/node.go
@@ -26,6 +26,7 @@ const (
 	Image
 	Text
 	HTMLBlock
+	HTMLComment
 	CodeBlock
 	Softbreak
 	Hardbreak
@@ -53,6 +54,7 @@ var nodeTypeNames = []string{
 	Image:          "Image",
 	Text:           "Text",
 	HTMLBlock:      "HTMLBlock",
+	HTMLComment:    "HTMLComment",
 	CodeBlock:      "CodeBlock",
 	Softbreak:      "Softbreak",
 	Hardbreak:      "Hardbreak",


### PR DESCRIPTION
- relates to https://github.com/cpuguy83/go-md2man/pull/104

This allows users of this library to handle HTML-comments different than other HTML blocks.