### PR TITLE
Use p.inline instead of p.block for intermediate render of inline item

### DIFF
--- a/block.go
+++ b/block.go
@@ -1295,7 +1295,7 @@ gatherlines:
 		// intermediate render of inline item
 		if sublist > 0 {
 			p.inline(&cooked, rawBytes[:sublist])
-			p.block(&cooked, rawBytes[sublist:])
+			p.inline(&cooked, rawBytes[sublist:])
 		} else {
 			p.inline(&cooked, rawBytes)
 		}


### PR DESCRIPTION
This PR fixes a copy-paste error in block.go. In its section for intermediate render of inline item, the incorrect `p.block` variable is used where it should be `p.inline`.